### PR TITLE
do not allow empty filenames

### DIFF
--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -148,6 +148,9 @@ def create(data: dict, user: str) -> dict:
     if file_count > 0:
         return file_already_exists
 
+    if len(filename) == 0:
+        return empty_name_not_allowed
+
     if len(filename) > 64:
         return name_too_long
 

--- a/app/scheme.py
+++ b/app/scheme.py
@@ -12,6 +12,8 @@ permission_denied: dict = make_error('no access to this device', origin='user')
 
 name_too_long: dict = make_error('name is too long', origin='user')
 
+empty_name_not_allowed: dict = make_error('empty names are not allowed', origin='user')
+
 no_name: dict = make_error('no name given', origin='user')
 
 this_device_does_not_exists: dict = make_error("this device does not exists", origin='user')


### PR DESCRIPTION
## Description
do not allow empty filenames

## Related Issue
see #24 

## Motivation and Context
In the official frontend files with empty filenames cannot be interacted with

## How Has This Been Tested?
tested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
