### PR TITLE
use func count

### DIFF
--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -1,5 +1,7 @@
 from typing import List, Optional
 
+from sqlalchemy import func
+
 from app import m, wrapper
 from models.device import Device
 from models.hardware import Hardware
@@ -114,7 +116,7 @@ def starter_device(data: dict, user: str) -> dict:
     :return: the response
     """
 
-    count: int = wrapper.session.query(Device).filter_by(owner=user).count()
+    count: int = wrapper.session.query(func.count(Device.uuid)).filter_by(owner=user).scalar()
 
     if count > 0:
         return already_own_a_device

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from sqlalchemy import func
+
 from app import m, wrapper
 from models.device import Device
 from models.file import File
@@ -172,7 +174,9 @@ def create_file(data: dict, user: str) -> dict:
     filename: str = data["filename"]
     content: str = data["content"]
 
-    file_count: int = wrapper.session.query(File).filter_by(device=device.uuid, filename=filename).count()
+    file_count: int = wrapper.session.query(func.count(File.uuid)).filter_by(
+        device=device.uuid, filename=filename
+    ).scalar()
 
     if file_count > 0:
         return file_already_exists


### PR DESCRIPTION
## Description
use `func.count()` instead of `query.count()`

## Related Issue
#47 

## How Has This Been Tested?
tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
