### PR TITLE
implemented directories

### DIFF
--- a/app/models/file.py
+++ b/app/models/file.py
@@ -33,8 +33,14 @@ class File(wrapper.Base):
         return d
 
     @staticmethod
-    def create(device: str, filename: str, content: str, parent_dir_uuid: Optional[str],
-               is_directory: bool, is_changeable: bool) -> "File":
+    def create(
+        device: str,
+        filename: str,
+        content: str,
+        parent_dir_uuid: Optional[str],
+        is_directory: bool,
+        is_changeable: bool,
+    ) -> "File":
         """
         Creates a new file
         :param device: The device's uuid
@@ -49,8 +55,15 @@ class File(wrapper.Base):
         uuid = str(uuid4())
 
         # Return a new file
-        file: File = File(uuid=uuid, device=device, filename=filename, content=content, parent_dir_uuid=parent_dir_uuid,
-                          is_directory=is_directory, is_changeable=is_changeable)
+        file: File = File(
+            uuid=uuid,
+            device=device,
+            filename=filename,
+            content=content,
+            parent_dir_uuid=parent_dir_uuid,
+            is_directory=is_directory,
+            is_changeable=is_changeable,
+        )
 
         wrapper.session.add(file)
         wrapper.session.commit()

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -17,7 +17,7 @@ class File(wrapper.Base):
 
     uuid: Union[Column, str] = Column(String(36), primary_key=True, unique=True)
     device: Union[Column, str] = Column(String(36), nullable=False)
-    filename: Union[Column, str] = Column(String(255, collation='utf8_bin'), nullable=False)
+    filename: Union[Column, str] = Column(String(255, collation="utf8_bin"), nullable=False)
     content: Union[Column, str] = Column(String(CONTENT_LENGTH), nullable=False)
     is_directory: Union[Column, bool] = Column(Boolean, nullable=False, default=False)
     parent_dir_uuid: Union[Column, str] = Column(String(36))

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -1,7 +1,7 @@
 from typing import Union
 from uuid import uuid4
 
-from sqlalchemy import Column, String
+from sqlalchemy import Column, String, Boolean
 
 from app import wrapper
 
@@ -19,6 +19,9 @@ class File(wrapper.Base):
     device: Union[Column, str] = Column(String(36), nullable=False)
     filename: Union[Column, str] = Column(String(255), nullable=False)
     content: Union[Column, str] = Column(String(CONTENT_LENGTH), nullable=False)
+    is_directory: Union[Column, bool] = Column(Boolean, nullable=False, default=False)
+    parent_dir_uuid: Union[Column, str] = Column(String(36))
+    is_changeable: [Union, bool] = Column(Boolean, nullable=False, default=True)
 
     @property
     def serialize(self) -> dict:
@@ -30,19 +33,24 @@ class File(wrapper.Base):
         return d
 
     @staticmethod
-    def create(device: str, filename: str, content: str) -> "File":
+    def create(device: str, filename: str, parent_dir_uuid: str, content: str = "",
+               is_directory: bool = False, is_changeable: bool = False) -> "File":
         """
         Creates a new file
         :param device: The device's uuid
         :param filename: The name of the new file
+        :param parent_dir_uuid: The parent directory (uuid) of the new file
         :param content: The content of the new file
+        :param is_directory: If the new file is a directory
+        :param is_changeable: If the new file is changeable by the user (move, filename, content)
         :return: New File
         """
 
         uuid = str(uuid4())
 
         # Return a new file
-        file: File = File(uuid=uuid, device=device, filename=filename, content=content)
+        file: File = File(uuid=uuid, device=device, filename=filename, content=content, parent_dir_uuid=parent_dir_uuid,
+                          is_directory=is_directory, is_changeable=is_changeable)
 
         wrapper.session.add(file)
         wrapper.session.commit()

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -17,7 +17,7 @@ class File(wrapper.Base):
 
     uuid: Union[Column, str] = Column(String(36), primary_key=True, unique=True)
     device: Union[Column, str] = Column(String(36), nullable=False)
-    filename: Union[Column, str] = Column(String(255), nullable=False)
+    filename: Union[Column, str] = Column(String(255, collation='utf8_bin'), nullable=False)
     content: Union[Column, str] = Column(String(CONTENT_LENGTH), nullable=False)
     is_directory: Union[Column, bool] = Column(Boolean, nullable=False, default=False)
     parent_dir_uuid: Union[Column, str] = Column(String(36))

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -21,7 +21,6 @@ class File(wrapper.Base):
     content: Union[Column, str] = Column(String(CONTENT_LENGTH), nullable=False)
     is_directory: Union[Column, bool] = Column(Boolean, nullable=False, default=False)
     parent_dir_uuid: Union[Column, str] = Column(String(36))
-    is_changeable: [Union, bool] = Column(Boolean, nullable=False, default=True)
 
     @property
     def serialize(self) -> dict:
@@ -33,14 +32,7 @@ class File(wrapper.Base):
         return d
 
     @staticmethod
-    def create(
-        device: str,
-        filename: str,
-        content: str,
-        parent_dir_uuid: Optional[str],
-        is_directory: bool,
-        is_changeable: bool,
-    ) -> "File":
+    def create(device: str, filename: str, content: str, parent_dir_uuid: Optional[str], is_directory: bool,) -> "File":
         """
         Creates a new file
         :param device: The device's uuid
@@ -48,7 +40,6 @@ class File(wrapper.Base):
         :param parent_dir_uuid: The parent directory (uuid) of the new file
         :param content: The content of the new file
         :param is_directory: If the new file is a directory
-        :param is_changeable: If the new file is changeable by the user (move, filename, content)
         :return: New File
         """
 
@@ -62,7 +53,6 @@ class File(wrapper.Base):
             content=content,
             parent_dir_uuid=parent_dir_uuid,
             is_directory=is_directory,
-            is_changeable=is_changeable,
         )
 
         wrapper.session.add(file)

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 from uuid import uuid4
 
 from sqlalchemy import Column, String, Boolean
@@ -33,8 +33,8 @@ class File(wrapper.Base):
         return d
 
     @staticmethod
-    def create(device: str, filename: str, parent_dir_uuid: str, content: str = "",
-               is_directory: bool = False, is_changeable: bool = False) -> "File":
+    def create(device: str, filename: str, content: str, parent_dir_uuid: Optional[str],
+               is_directory: bool, is_changeable: bool) -> "File":
         """
         Creates a new file
         :param device: The device's uuid

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -4,7 +4,6 @@ from sqlalchemy import func
 
 from app import m, wrapper
 from models.device import Device
-from models.file import File
 from models.hardware import Hardware
 from models.workload import Workload
 from models.service import Service
@@ -107,7 +106,7 @@ def create_device(data: dict, user: str) -> dict:
 
     delete_items(user, data)
 
-    File(device.uuid, "/", None, "", True, False)
+    File.create(device.uuid, "/", None, "", True, False)
 
     return device.serialize
 

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -106,7 +106,7 @@ def create_device(data: dict, user: str) -> dict:
 
     delete_items(user, data)
 
-    File.create(device.uuid, "/", None, "", True, False)
+    File.create(device.uuid, "/", "", None, True, False)
 
     return device.serialize
 

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -207,6 +207,9 @@ def delete_device(data: dict, user: str) -> dict:
 
     stop_all_service(data["device_uuid"], delete=True)
     delete_services(data["device_uuid"])  # Removes all Services in MS_Service
+    files: list = wrapper.session.query(File).filter_by(device=device.uuid)
+    for file in files:
+        wrapper.session.delete(file)
 
     device: Device = wrapper.session.query(Device).get(data["device_uuid"])
     wrapper.session.delete(device)
@@ -273,6 +276,11 @@ def delete_user(data: dict, microservice: str) -> dict:
         # delete all services running on the device
         for service in wrapper.session.query(Service).filter_by(device_uuid=device.uuid):
             wrapper.session.delete(service)
+
+        #delete all files in filesystem
+        files: list = wrapper.session.query(File).filter_by(device=device.uuid)
+        for file in files:
+            wrapper.session.delete(file)
 
         # delete the device itself
         wrapper.session.delete(device)

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -17,6 +17,7 @@ from resources.game_content import (
     stop_all_service,
     stop_services,
     delete_services,
+    delete_files,
 )
 from schemes import (
     success,
@@ -207,9 +208,7 @@ def delete_device(data: dict, user: str) -> dict:
 
     stop_all_service(data["device_uuid"], delete=True)
     delete_services(data["device_uuid"])  # Removes all Services in MS_Service
-    files: list = wrapper.session.query(File).filter_by(device=device.uuid)
-    for file in files:
-        wrapper.session.delete(file)
+    delete_files(data["device_uuid"])     # remove all files
 
     device: Device = wrapper.session.query(Device).get(data["device_uuid"])
     wrapper.session.delete(device)
@@ -276,11 +275,6 @@ def delete_user(data: dict, microservice: str) -> dict:
         # delete all services running on the device
         for service in wrapper.session.query(Service).filter_by(device_uuid=device.uuid):
             wrapper.session.delete(service)
-
-        #delete all files in filesystem
-        files: list = wrapper.session.query(File).filter_by(device=device.uuid)
-        for file in files:
-            wrapper.session.delete(file)
 
         # delete the device itself
         wrapper.session.delete(device)

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -8,6 +8,7 @@ from models.file import File
 from models.hardware import Hardware
 from models.workload import Workload
 from models.service import Service
+from models.file import File
 from resources.game_content import (
     check_compatible,
     calculate_power,
@@ -105,6 +106,8 @@ def create_device(data: dict, user: str) -> dict:
     create_hardware(data, device.uuid)
 
     delete_items(user, data)
+
+    File(device.uuid, "/", None, "", True, False)
 
     return device.serialize
 

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -133,6 +133,8 @@ def starter_device(data: dict, user: str) -> dict:
 
     create_hardware(hardware["start_pc"], device.uuid)
 
+    File.create(device.uuid, "/", "", None, True, False)
+
     return device.serialize
 
 

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -109,8 +109,6 @@ def create_device(data: dict, user: str) -> dict:
 
     delete_items(user, data)
 
-    File.create(device.uuid, "/", "", None, True, False)
-
     m.contact_microservice("service", ["device_init"], {"device_uuid": device.uuid, "user": device.owner})
 
     return device.serialize
@@ -137,8 +135,6 @@ def starter_device(data: dict, user: str) -> dict:
     Workload.create(device.uuid, performance)
 
     create_hardware(hardware["start_pc"], device.uuid)
-
-    File.create(device.uuid, "/", "", None, True, False)
 
     m.contact_microservice("service", ["device_init"], {"device_uuid": device.uuid, "user": device.owner})
 

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -208,7 +208,7 @@ def delete_device(data: dict, user: str) -> dict:
 
     stop_all_service(data["device_uuid"], delete=True)
     delete_services(data["device_uuid"])  # Removes all Services in MS_Service
-    delete_files(data["device_uuid"])     # remove all files
+    delete_files(data["device_uuid"])  # remove all files
 
     device: Device = wrapper.session.query(Device).get(data["device_uuid"])
     wrapper.session.delete(device)

--- a/app/resources/errors.py
+++ b/app/resources/errors.py
@@ -1,9 +1,10 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 from app import wrapper
 from cryptic import MicroserviceException
 from models.device import Device
-from schemes import device_not_found, permission_denied, device_powered_off
+from models.file import File
+from schemes import device_not_found, permission_denied, device_powered_off, file_not_found
 
 
 def device_exists(data: dict, user: str) -> Device:
@@ -27,3 +28,12 @@ def device_powered_on(data: dict, user: str, device: Device) -> Device:
         raise MicroserviceException(device_powered_off)
 
     return device
+
+
+def file_exists(data: dict, user: str, device: Device) -> Tuple[Device, File]:
+    file: Optional[File] = wrapper.session.query(File).filter_by(device=device.uuid, uuid=data["file_uuid"]).first()
+
+    if file is None:
+        raise MicroserviceException(file_not_found)
+
+    return device, file

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -22,6 +22,7 @@ from schemes import (
     file_not_changeable,
     can_not_move_dir_into_itself,
     basic_file_requirement,
+    parent_dir_does_not_exist,
 )
 
 
@@ -256,6 +257,10 @@ def create_file(data: dict, user: str) -> dict:
 
     if file_count > 0:
         return file_already_exists
+
+    parent_dir: File = wrapper.session.query(File).filter_by(device=device.uuid, parent_dir_uuid=parent_dir_uuid)
+    if not parent_dir:
+        return parent_dir_does_not_exist
 
     if is_directory and content != "":
         return directory_can_not_have_textcontent

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -22,7 +22,6 @@ from schemes import (
     file_not_changeable,
     can_not_move_dir_into_itself,
     basic_file_requirement,
-    parent_dir_does_not_exist,
 )
 
 
@@ -261,7 +260,7 @@ def create_file(data: dict, user: str) -> dict:
     parent_dir: File = wrapper.session.query(File).filter_by(device=device.uuid, parent_dir_uuid=parent_dir_uuid,
                                                              is_directory=True).first()
     if not parent_dir:
-        return parent_dir_does_not_exist
+        return parent_directory_not_found
 
     if is_directory and content != "":
         return directory_can_not_have_textcontent

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -81,12 +81,13 @@ def move(data: dict, user: str, device: Device, file: File) -> dict:
         parent_to_check: Optional[File] = wrapper.session.query(File).filter_by(
             device=device.uuid, uuid=new_parent_dir_uuid
         ).first()
-        while parent_to_check.parent_dir_uuid is not None:
-            if parent_to_check.uuid == file.uuid:
-                return can_not_move_dir_into_itself
-            parent_to_check: Optional[File] = wrapper.session.query(File).filter_by(
-                device=device.uuid, uuid=parent_to_check.parent_dir_uuid
-            ).first()
+        if parent_to_check is not None:
+            while parent_to_check.parent_dir_uuid is not None:
+                if parent_to_check.uuid == file.uuid:
+                    return can_not_move_dir_into_itself
+                parent_to_check: Optional[File] = wrapper.session.query(File).filter_by(
+                    device=device.uuid, uuid=parent_to_check.parent_dir_uuid
+                ).first()
 
     file.filename = new_filename
     file.parent_dir_uuid = new_parent_dir_uuid

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -249,7 +249,6 @@ def create_file(data: dict, user: str) -> dict:
     content: str = data["content"]
     is_directory: bool = data["is_directory"]
     parent_dir_uuid: str = data["parent_dir_uuid"]
-    is_changeable: bool = data["is_changeable"]
 
     file_count: int = wrapper.session.query(func.count(File.uuid)).filter_by(
         device=device.uuid, filename=filename, parent_dir_uuid=parent_dir_uuid
@@ -261,6 +260,6 @@ def create_file(data: dict, user: str) -> dict:
     if is_directory and content != "":
         return directory_can_not_have_textcontent
 
-    file: File = File.create(device.uuid, filename, content, parent_dir_uuid, is_directory, is_changeable)
+    file: File = File.create(device.uuid, filename, content, parent_dir_uuid, is_directory, True)
 
     return file.serialize

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -258,7 +258,8 @@ def create_file(data: dict, user: str) -> dict:
     if file_count > 0:
         return file_already_exists
 
-    parent_dir: File = wrapper.session.query(File).filter_by(device=device.uuid, parent_dir_uuid=parent_dir_uuid)
+    parent_dir: File = wrapper.session.query(File).filter_by(device=device.uuid, parent_dir_uuid=parent_dir_uuid,
+                                                             is_directory=True).first()
     if not parent_dir:
         return parent_dir_does_not_exist
 

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -78,7 +78,7 @@ def move(data: dict, user: str, device: Device, file: File) -> dict:
     target_dir: Optional[File] = (
         wrapper.session.query(File).filter_by(device=device.uuid, is_directory=True, uuid=new_parent_dir_uuid).first()
     )
-    if target_dir is None:
+    if target_dir is None and new_parent_dir_uuid is not None:
         return parent_directory_not_found
 
     if file.is_directory:
@@ -230,7 +230,7 @@ def create_file(data: dict, user: str, device: Device) -> dict:
     parent_dir: File = wrapper.session.query(File).filter_by(
         device=device.uuid, uuid=parent_dir_uuid, is_directory=True
     ).first()
-    if not parent_dir:
+    if not parent_dir and parent_dir_uuid is not None:
         return parent_directory_not_found
 
     if is_directory and content != "":

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -258,8 +258,9 @@ def create_file(data: dict, user: str) -> dict:
     if file_count > 0:
         return file_already_exists
 
-    parent_dir: File = wrapper.session.query(File).filter_by(device=device.uuid, parent_dir_uuid=parent_dir_uuid,
-                                                             is_directory=True).first()
+    parent_dir: File = wrapper.session.query(File).filter_by(
+        device=device.uuid, uuid=parent_dir_uuid, is_directory=True
+    ).first()
     if not parent_dir:
         return parent_dir_does_not_exist
 

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -21,11 +21,11 @@ from schemes import (
     parent_directory_not_found,
     file_not_changeable,
     can_not_move_dir_into_itself,
-    requirement_device,
+    basic_file_requirement,
 )
 
 
-@m.user_endpoint(path=["file", "all"], requires=requirement_device)
+@m.user_endpoint(path=["file", "all"], requires=basic_file_requirement)
 def list_files(data: dict, user: str) -> dict:
     """
     Get all files of a device.

--- a/app/resources/game_content.py
+++ b/app/resources/game_content.py
@@ -5,6 +5,7 @@ from app import m, wrapper
 from models.hardware import Hardware
 from models.service import Service
 from models.workload import Workload
+from models.file import File
 from vars import hardware, resolve_ram_type, resolve_gpu_type
 
 
@@ -196,6 +197,12 @@ def stop_services(device_uuid: str) -> None:
 
 def delete_services(device_uuid: str) -> None:
     m.contact_microservice("service", ["hardware", "delete"], {"device_uuid": device_uuid})
+
+
+def delete_files(device_uuid: str) -> None:
+    files: list = wrapper.session.query(File).filter_by(device=device_uuid)
+    for file in files:
+        wrapper.session.delete(file)
 
 
 def generate_scale_with_no_new(wl: Workload) -> Tuple[float, float, float, float, float]:

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -19,8 +19,6 @@ file_already_exists: dict = make_error("file_already_exists", origin="user")
 
 directory_can_not_have_textcontent: dict = make_error("directory_can_not_have_textcontent", origin="user")
 
-parent_dir_does_not_exist: dict = make_error("parent directory for new file does not exist", origin="user")
-
 directories_can_not_be_updated: dict = make_error("directories_can_not_be_updated", origin="user")
 
 parent_directory_not_found: dict = make_error("parent_directory_not_found", origin="user")

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -19,6 +19,8 @@ file_already_exists: dict = make_error("file_already_exists", origin="user")
 
 directory_can_not_have_textcontent: dict = make_error("directory_can_not_have_textcontent", origin="user")
 
+parent_dir_does_not_exist: dict = make_error("parent directory for new file does not exist", origin="user")
+
 directories_can_not_be_updated: dict = make_error("directories_can_not_be_updated", origin="user")
 
 parent_directory_not_found: dict = make_error("parent_directory_not_found", origin="user")

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -37,7 +37,7 @@ success: dict = {"ok": True}
 
 requirement_device: dict = {"device_uuid": UUID()}
 
-basic_file_requirement: dict = {"device_uuid": UUID(), "parent_dir_uuid": str}
+basic_file_requirement: dict = {"device_uuid": UUID(), "parent_dir_uuid": UUID()}
 
 requirement_change_name: dict = {"device_uuid": UUID(), "name": Text(min_length=1, max_length=15)}
 

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -1,4 +1,4 @@
-from scheme import Text, Sequence, UUID
+from scheme import Text, Sequence, UUID, Boolean
 
 from models.file import CONTENT_LENGTH
 
@@ -16,6 +16,18 @@ device_not_found: dict = make_error("device_not_found", origin="user")
 file_not_found: dict = make_error("file_not_found", origin="user")
 
 file_already_exists: dict = make_error("file_already_exists", origin="user")
+
+directory_can_not_have_textcontent: dict = make_error("directory_can_not_have_textcontent", origin="user")
+
+directories_can_not_be_updated: dict = make_error("directories_can_not_be_updated", origin="user")
+
+directories_must_be_deleted_recursively: dict = make_error("directories_must_be_deleted_recursively", origin="user")
+
+parent_directory_not_found: dict = make_error("parent_directory_not_found", origin="user")
+
+file_not_changeable: dict = make_error("file_not_changeable", origin="user")
+
+can_not_move_dir_into_itself: dict = make_error("can_not_move_dir_into_itself", origin="user")
 
 service_not_found: dict = make_error("service_not_found", origin="service")
 
@@ -39,10 +51,13 @@ requirement_build: dict = {
 
 requirement_file: dict = {"device_uuid": UUID(), "file_uuid": UUID()}
 
+requirement_file_delete: dict = {"device_uuid": UUID(), "file_uuid": UUID(), "recursive": Boolean}
+
 requirement_file_move: dict = {
     "device_uuid": UUID(),
     "file_uuid": UUID(),
     "filename": Text(min_length=1, max_length=64),
+    "parent_dir": UUID(),
 }
 
 requirement_file_update: dict = {"device_uuid": UUID(), "file_uuid": UUID(), "content": Text(max_length=CONTENT_LENGTH)}
@@ -51,6 +66,9 @@ requirement_file_create: dict = {
     "device_uuid": UUID(),
     "filename": Text(min_length=1, max_length=64),
     "content": Text(max_length=CONTENT_LENGTH),
+    "is_directory": Boolean,
+    "parent_dir": UUID(),
+    "is_changeable": Boolean,
 }
 
 requirement_service: dict = {"service_uuid": UUID()}

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -21,8 +21,6 @@ directory_can_not_have_textcontent: dict = make_error("directory_can_not_have_te
 
 directories_can_not_be_updated: dict = make_error("directories_can_not_be_updated", origin="user")
 
-directories_must_be_deleted_recursively: dict = make_error("directories_must_be_deleted_recursively", origin="user")
-
 parent_directory_not_found: dict = make_error("parent_directory_not_found", origin="user")
 
 file_not_changeable: dict = make_error("file_not_changeable", origin="user")

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -68,7 +68,6 @@ requirement_file_create: dict = {
     "content": Text(max_length=CONTENT_LENGTH),
     "is_directory": Boolean(),
     "parent_dir_uuid": UUID(),
-    "is_changeable": Boolean(),
 }
 
 requirement_service: dict = {"service_uuid": UUID()}

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -39,7 +39,7 @@ requirement_device: dict = {"device_uuid": UUID()}
 
 basic_file_requirement: dict = {"device_uuid": UUID(), "parent_dir_uuid": UUID()}
 
-requirement_change_name: dict = {"device_uuid": UUID(), "name": Text(min_length=1, max_length=15)}
+requirement_change_name: dict = {"device_uuid": UUID(), "name": Text(pattern=r"^[a-zA-Z0-9\-_]{1,15}$")}
 
 requirement_build: dict = {
     "gpu": Text(),
@@ -56,7 +56,7 @@ requirement_file_delete: dict = {"device_uuid": UUID(), "file_uuid": UUID()}
 requirement_file_move: dict = {
     "device_uuid": UUID(),
     "file_uuid": UUID(),
-    "new_filename": Text(min_length=1, max_length=64),
+    "new_filename": Text(pattern=r"^[a-zA-Z0-9\-_.]{1,64}$"),
     "new_parent_dir_uuid": UUID(),
 }
 
@@ -64,7 +64,7 @@ requirement_file_update: dict = {"device_uuid": UUID(), "file_uuid": UUID(), "co
 
 requirement_file_create: dict = {
     "device_uuid": UUID(),
-    "filename": Text(min_length=1, max_length=64),
+    "filename": Text(pattern=r"^[a-zA-Z0-9\-_.]{1,64}$"),
     "content": Text(max_length=CONTENT_LENGTH),
     "is_directory": Boolean(),
     "parent_dir_uuid": UUID(),

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -37,7 +37,15 @@ success: dict = {"ok": True}
 
 requirement_device: dict = {"device_uuid": UUID()}
 
-requirement_change_name: dict = {"device_uuid": UUID(), "name": Text(min_length=1, max_length=15)}
+basic_file_requirement: dict = {
+    "device_uuid": UUID(),
+    "parent_dir_uuid": str
+}
+
+requirement_change_name: dict = {
+    "device_uuid": UUID(),
+    "name": Text(min_length=1, max_length=15)
+}
 
 requirement_build: dict = {
     "gpu": Text(),
@@ -49,24 +57,34 @@ requirement_build: dict = {
 
 requirement_file: dict = {"device_uuid": UUID(), "file_uuid": UUID()}
 
-requirement_file_delete: dict = {"device_uuid": UUID(), "file_uuid": UUID(), "recursive": Boolean}
+requirement_file_delete: dict = {
+    "device_uuid": UUID(),
+    "file_uuid": UUID(),
+    "recursive": Boolean
+}
 
 requirement_file_move: dict = {
     "device_uuid": UUID(),
     "file_uuid": UUID(),
-    "filename": Text(min_length=1, max_length=64),
-    "parent_dir": UUID(),
+    "new_filename": Text(min_length=1, max_length=64),
+    "new_parent_dir_uuid": UUID(),
 }
 
-requirement_file_update: dict = {"device_uuid": UUID(), "file_uuid": UUID(), "content": Text(max_length=CONTENT_LENGTH)}
+requirement_file_update: dict = {
+    "device_uuid": UUID(),
+    "file_uuid": UUID(),
+    "content": Text(max_length=CONTENT_LENGTH)
+}
 
 requirement_file_create: dict = {
     "device_uuid": UUID(),
     "filename": Text(min_length=1, max_length=64),
     "content": Text(max_length=CONTENT_LENGTH),
     "is_directory": Boolean,
-    "parent_dir": UUID(),
+    "parent_dir_uuid": UUID(),
     "is_changeable": Boolean,
 }
 
-requirement_service: dict = {"service_uuid": UUID()}
+requirement_service: dict = {
+    "service_uuid": UUID()
+}

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -37,15 +37,9 @@ success: dict = {"ok": True}
 
 requirement_device: dict = {"device_uuid": UUID()}
 
-basic_file_requirement: dict = {
-    "device_uuid": UUID(),
-    "parent_dir_uuid": str
-}
+basic_file_requirement: dict = {"device_uuid": UUID(), "parent_dir_uuid": str}
 
-requirement_change_name: dict = {
-    "device_uuid": UUID(),
-    "name": Text(min_length=1, max_length=15)
-}
+requirement_change_name: dict = {"device_uuid": UUID(), "name": Text(min_length=1, max_length=15)}
 
 requirement_build: dict = {
     "gpu": Text(),
@@ -57,11 +51,7 @@ requirement_build: dict = {
 
 requirement_file: dict = {"device_uuid": UUID(), "file_uuid": UUID()}
 
-requirement_file_delete: dict = {
-    "device_uuid": UUID(),
-    "file_uuid": UUID(),
-    "recursive": Boolean
-}
+requirement_file_delete: dict = {"device_uuid": UUID(), "file_uuid": UUID(), "recursive": Boolean}
 
 requirement_file_move: dict = {
     "device_uuid": UUID(),
@@ -70,11 +60,7 @@ requirement_file_move: dict = {
     "new_parent_dir_uuid": UUID(),
 }
 
-requirement_file_update: dict = {
-    "device_uuid": UUID(),
-    "file_uuid": UUID(),
-    "content": Text(max_length=CONTENT_LENGTH)
-}
+requirement_file_update: dict = {"device_uuid": UUID(), "file_uuid": UUID(), "content": Text(max_length=CONTENT_LENGTH)}
 
 requirement_file_create: dict = {
     "device_uuid": UUID(),
@@ -85,6 +71,4 @@ requirement_file_create: dict = {
     "is_changeable": Boolean,
 }
 
-requirement_service: dict = {
-    "service_uuid": UUID()
-}
+requirement_service: dict = {"service_uuid": UUID()}

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -51,7 +51,7 @@ requirement_build: dict = {
 
 requirement_file: dict = {"device_uuid": UUID(), "file_uuid": UUID()}
 
-requirement_file_delete: dict = {"device_uuid": UUID(), "file_uuid": UUID(), "recursive": Boolean}
+requirement_file_delete: dict = {"device_uuid": UUID(), "file_uuid": UUID()}
 
 requirement_file_move: dict = {
     "device_uuid": UUID(),
@@ -66,9 +66,9 @@ requirement_file_create: dict = {
     "device_uuid": UUID(),
     "filename": Text(min_length=1, max_length=64),
     "content": Text(max_length=CONTENT_LENGTH),
-    "is_directory": Boolean,
+    "is_directory": Boolean(),
     "parent_dir_uuid": UUID(),
-    "is_changeable": Boolean,
+    "is_changeable": Boolean(),
 }
 
 requirement_service: dict = {"service_uuid": UUID()}

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -27,8 +27,6 @@ directories_can_not_be_updated: dict = make_error("directories_can_not_be_update
 
 parent_directory_not_found: dict = make_error("parent_directory_not_found", origin="user")
 
-file_not_changeable: dict = make_error("file_not_changeable", origin="user")
-
 can_not_move_dir_into_itself: dict = make_error("can_not_move_dir_into_itself", origin="user")
 
 service_not_found: dict = make_error("service_not_found", origin="service")

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -12,6 +12,7 @@ from schemes import (
     requirement_file_update,
     requirement_file_create,
     requirement_service,
+    requirement_file_delete
 )
 
 
@@ -68,7 +69,7 @@ class TestApp(TestCase):
             (["file", "info"], requirement_file, file.file_info),
             (["file", "move"], requirement_file_move, file.move),
             (["file", "update"], requirement_file_update, file.update),
-            (["file", "delete"], requirement_file, file.delete_file),
+            (["file", "delete"], requirement_file_delete, file.delete_file),
             (["file", "create"], requirement_file_create, file.create_file),
             (["hardware", "build"], requirement_build, hardware.build),
             (["hardware", "resources"], requirement_device, hardware.hardware_resources),

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -12,7 +12,7 @@ from schemes import (
     requirement_file_update,
     requirement_file_create,
     requirement_service,
-    requirement_file_delete
+    requirement_file_delete,
 )
 
 

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -291,6 +291,11 @@ class TestDevice(TestCase):
     def test__user_endpoint__device_delete__successful(self, sas_patch, ds_patch):
         mock_device = mock.MagicMock()
         mock_device.owner = "user"
+        files = []
+        for i in range(5):
+            files.append([mock.MagicMock() for _ in range(5)])
+
+        self.query_file.filter_by.return_value = files
         self.query_device.get.return_value = mock_device
 
         expected_result = success

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -140,7 +140,6 @@ class TestDevice(TestCase):
         workload_patch.create.assert_called_with(mock_device.uuid, calculate_patch())
         create_patch.assert_called_with(data, mock_device.uuid)
         delete_patch.assert_called_with("user", data)
-        file_patch.create.assert_called_with(mock_device.uuid, "/", "", None, True, False)
         mock.m.contact_microservice.assert_called_with(
             "service", ["device_init"], {"device_uuid": mock_device.uuid, "user": mock_device.owner}
         )
@@ -177,7 +176,6 @@ class TestDevice(TestCase):
         device_create_patch.assert_called_with("user", True)
         workload_patch.create.assert_called_with(mock_device.uuid, calculate_patch())
         create_patch.assert_called_with(hardware["start_pc"], mock_device.uuid)
-        file_patch.create.assert_called_with(mock_device.uuid, "/", "", None, True, False)
         mock.m.contact_microservice.assert_called_with(
             "service", ["device_init"], {"device_uuid": mock_device.uuid, "user": mock_device.owner}
         )

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -110,7 +110,7 @@ class TestDevice(TestCase):
         compatible_patch.assert_called_with(data)
         exists_patch.assert_called_with("user", data)
 
-    @patch("resources.file.File")
+    @patch("resources.device.File")
     @patch("resources.device.delete_items")
     @patch("resources.device.create_hardware")
     @patch("resources.device.calculate_power")
@@ -139,7 +139,7 @@ class TestDevice(TestCase):
         workload_patch.create.assert_called_with(mock_device.uuid, calculate_patch())
         create_patch.assert_called_with(data, mock_device.uuid)
         delete_patch.assert_called_with("user", data)
-        file_patch.create.assert_called_with(mock_device.device_uuid, "/", None, "", True, False)
+        file_patch.create.assert_called_with(mock_device.uuid, "/", "", None, True, False)
 
     def test__user_endpoint__device_starter_device__already_own_a_device(self):
         self.query_func_count.filter_by().scalar.return_value = 1

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -119,8 +119,15 @@ class TestDevice(TestCase):
     @patch("resources.device.check_exists")
     @patch("resources.device.check_compatible")
     def test__user_endpoint__device_create__successful(
-        self, compatible_patch, exists_patch, device_patch, workload_patch, calculate_patch, create_patch, delete_patch,
-            file_patch
+        self,
+        compatible_patch,
+        exists_patch,
+        device_patch,
+        workload_patch,
+        calculate_patch,
+        create_patch,
+        delete_patch,
+        file_patch,
     ):
         compatible_patch.return_value = True, {}
         exists_patch.return_value = True, {}

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -110,6 +110,7 @@ class TestDevice(TestCase):
         compatible_patch.assert_called_with(data)
         exists_patch.assert_called_with("user", data)
 
+    @patch("resources.file.File")
     @patch("resources.device.delete_items")
     @patch("resources.device.create_hardware")
     @patch("resources.device.calculate_power")
@@ -118,7 +119,8 @@ class TestDevice(TestCase):
     @patch("resources.device.check_exists")
     @patch("resources.device.check_compatible")
     def test__user_endpoint__device_create__successful(
-        self, compatible_patch, exists_patch, device_patch, workload_patch, calculate_patch, create_patch, delete_patch
+        self, compatible_patch, exists_patch, device_patch, workload_patch, calculate_patch, create_patch, delete_patch,
+            file_patch
     ):
         compatible_patch.return_value = True, {}
         exists_patch.return_value = True, {}
@@ -137,6 +139,7 @@ class TestDevice(TestCase):
         workload_patch.create.assert_called_with(mock_device.uuid, calculate_patch())
         create_patch.assert_called_with(data, mock_device.uuid)
         delete_patch.assert_called_with("user", data)
+        file_patch.create.assert_called_with(mock_device.device_uuid, "/", None, "", True, False)
 
     def test__user_endpoint__device_starter_device__already_own_a_device(self):
         self.query_func_count.filter_by().scalar.return_value = 1

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -158,12 +158,13 @@ class TestDevice(TestCase):
         self.sqlalchemy_func.count.assert_called_with(Device.uuid)
         self.query_func_count.filter_by.assert_called_with(owner="user")
 
+    @patch("resources.device.File")
     @patch("resources.device.create_hardware")
     @patch("resources.device.calculate_power")
     @patch("resources.device.Workload")
     @patch("resources.device.Device.create")
     def test__user_endpoint__device_starter_device__successful(
-        self, device_create_patch, workload_patch, calculate_patch, create_patch
+        self, device_create_patch, workload_patch, calculate_patch, create_patch, file_patch
     ):
         self.query_func_count.filter_by().scalar.return_value = 0
 
@@ -179,6 +180,7 @@ class TestDevice(TestCase):
         device_create_patch.assert_called_with("user", True)
         workload_patch.create.assert_called_with(mock_device.uuid, calculate_patch())
         create_patch.assert_called_with(hardware["start_pc"], mock_device.uuid)
+        file_patch.create.assert_called_with(mock_device.uuid, "/", "", None, True, False)
 
     def test__user_endpoint__device_power__device_not_found(self):
         self.query_device.get.return_value = None

--- a/app/tests/test_errors.py
+++ b/app/tests/test_errors.py
@@ -2,9 +2,10 @@ from unittest import TestCase
 
 from mock.mock_loader import mock
 from models.device import Device
+from models.file import File
 from resources import errors
 from resources.errors import MicroserviceException
-from schemes import device_not_found, permission_denied, device_powered_off
+from schemes import device_not_found, permission_denied, device_powered_off, file_not_found
 
 
 class TestErrors(TestCase):
@@ -12,7 +13,8 @@ class TestErrors(TestCase):
         mock.reset_mocks()
 
         self.query_device = mock.MagicMock()
-        mock.wrapper.session.query.side_effect = {Device: self.query_device}.__getitem__
+        self.query_file = mock.MagicMock()
+        mock.wrapper.session.query.side_effect = {Device: self.query_device, File: self.query_file}.__getitem__
 
     def test__device_exists__device_not_found(self):
         self.query_device.get.return_value = None
@@ -60,3 +62,20 @@ class TestErrors(TestCase):
         mock_device.powered_on = True
 
         self.assertEqual(mock_device, errors.device_powered_on({}, "", mock_device))
+
+    def test__file_exists__device_not_found(self):
+        self.query_file.filter_by().first.return_value = None
+        mock_device = mock.MagicMock()
+
+        with self.assertRaises(MicroserviceException) as context:
+            errors.file_exists({"file_uuid": "my-file"}, "", mock_device)
+
+        self.assertEqual(file_not_found, context.exception.error)
+        self.query_file.filter_by.assert_called_with(device=mock_device.uuid, uuid="my-file")
+
+    def test__file_exists__successful(self):
+        mock_file = self.query_file.filter_by().first.return_value = mock.MagicMock()
+        mock_device = mock.MagicMock()
+
+        self.assertEqual((mock_device, mock_file), errors.file_exists({"file_uuid": "my-file"}, "", mock_device))
+        self.query_file.filter_by.assert_called_with(device=mock_device.uuid, uuid="my-file")

--- a/app/tests/test_file.py
+++ b/app/tests/test_file.py
@@ -4,9 +4,19 @@ from unittest.mock import patch
 from mock.mock_loader import mock
 from models.device import Device
 from models.file import File
-
 from resources import file
-from schemes import device_not_found, permission_denied, file_not_found, file_already_exists, success
+from schemes import (
+    device_not_found,
+    permission_denied,
+    file_not_found,
+    file_already_exists,
+    success,
+    directories_can_not_be_updated,
+    file_not_changeable,
+    parent_directory_not_found,
+    can_not_move_dir_into_itself,
+    directory_can_not_have_textcontent,
+)
 
 
 class TestFile(TestCase):
@@ -27,7 +37,7 @@ class TestFile(TestCase):
         self.query_device.get.return_value = None
 
         expected_result = device_not_found
-        actual_result = file.list_files({"device_uuid": "my-device"}, "user")
+        actual_result = file.list_files({"device_uuid": "my-device", "parent_dir_uuid": "0"}, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -39,7 +49,7 @@ class TestFile(TestCase):
         self.query_device.get.return_value = mock_device
 
         expected_result = permission_denied
-        actual_result = file.list_files({"device_uuid": "my-device"}, "user")
+        actual_result = file.list_files({"device_uuid": "my-device", "parent_dir_uuid": "0"}, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -54,18 +64,19 @@ class TestFile(TestCase):
         self.query_file.filter_by().all.return_value = files
 
         expected_result = {"files": [f.serialize for f in files]}
-        actual_result = file.list_files({"device_uuid": mock_device.uuid}, "user")
+        actual_result = file.list_files({"device_uuid": mock_device.uuid, "parent_dir_uuid": "0"}, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
         mock_device.check_access.assert_called_with("user")
-        self.query_file.filter_by.assert_called_with(device=mock_device.uuid)
+        self.query_file.filter_by.assert_called_with(device=mock_device.uuid, parent_dir_uuid="0")
 
     def test__user_endpoint__file_info__device_not_found(self):
         self.query_device.get.return_value = None
 
         expected_result = device_not_found
-        actual_result = file.file_info({"device_uuid": "my-device", "file_uuid": "my-file"}, "user")
+        actual_result = file.file_info({"device_uuid": "my-device", "file_uuid": "my-file"},
+                                       "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -77,7 +88,11 @@ class TestFile(TestCase):
         self.query_device.get.return_value = mock_device
 
         expected_result = permission_denied
-        actual_result = file.file_info({"device_uuid": "my-device", "file_uuid": "my-file"}, "user")
+        actual_result = file.file_info({
+            "device_uuid": "my-device",
+            "file_uuid": "my-file"
+        },
+            "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -91,7 +106,10 @@ class TestFile(TestCase):
         self.query_file.filter_by().first.return_value = None
 
         expected_result = file_not_found
-        actual_result = file.file_info({"device_uuid": mock_device.uuid, "file_uuid": "my-file"}, "user")
+        actual_result = file.file_info({
+            "device_uuid": mock_device.uuid,
+            "file_uuid": "my-file"
+        }, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
@@ -107,7 +125,10 @@ class TestFile(TestCase):
         self.query_file.filter_by().first.return_value = mock_file
 
         expected_result = mock_file.serialize
-        actual_result = file.file_info({"device_uuid": mock_device.uuid, "file_uuid": mock_file.uuid}, "user")
+        actual_result = file.file_info({
+            "device_uuid": mock_device.uuid,
+            "file_uuid": mock_file.uuid
+        }, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
@@ -121,8 +142,8 @@ class TestFile(TestCase):
         actual_result = file.move({
             "device_uuid": "my-device",
             "file_uuid": "my-file",
-            "filename": "new-name",
-            "parent_dir_uuid": "0"
+            "new_filename": "new-name",
+            "new_parent_dir_uuid": "0"
         }, "user")
 
         self.assertEqual(expected_result, actual_result)
@@ -138,8 +159,8 @@ class TestFile(TestCase):
         actual_result = file.move({
             "device_uuid": "my-device",
             "file_uuid": "my-file",
-            "filename": "new-name",
-            "parent_dir_uuid": "0"
+            "new_filename": "new-name",
+            "new_parent_dir_uuid": "0"
         }, "user")
 
         self.assertEqual(expected_result, actual_result)
@@ -157,8 +178,8 @@ class TestFile(TestCase):
         actual_result = file.move({
             "device_uuid": mock_device.uuid,
             "file_uuid": "my-file",
-            "filename": "new-name",
-            "parent_dir_uuid": "0"
+            "new_filename": "new-name",
+            "new_parent_dir_uuid": "0"
         }, "user"
         )
 
@@ -176,10 +197,11 @@ class TestFile(TestCase):
 
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
-            if "filename" in kwargs:
+            if "new_filename" in kwargs:
                 self.assertEqual({
                     "device": mock_device.uuid,
-                    "filename": "new-name"
+                    "new_filename": "new-name",
+                    "new_parent_dir_uuid": "0"
                 }, kwargs)
                 out.first.return_value = mock.MagicMock()
             else:
@@ -191,7 +213,134 @@ class TestFile(TestCase):
 
         expected_result = file_already_exists
         actual_result = file.move(
-            {"device_uuid": mock_device.uuid, "file_uuid": "my-file", "filename": "new-name"}, "user"
+            {"device_uuid": mock_device.uuid,
+             "file_uuid": "my-file",
+             "new_filename": "new-name",
+             "new_parent_dir_uuid": "0"
+             }, "user"
+        )
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        mock_device.check_access.assert_called_with("user")
+
+    def test__user_endpoint__file_move__file_not_changeable(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_file = mock.MagicMock()
+        mock_file.is_changeable = False
+
+        self.query_device.get.return_value = mock_device
+
+        def handle_file_query(**kwargs):
+            out = mock.MagicMock()
+            if "new_filename" in kwargs:
+                self.assertEqual({"device": mock_device.uuid, "new_filename": "new-name"}, kwargs)
+                out.first.return_value = None
+            else:
+                self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
+                out.first.return_value = mock_file
+            return out
+
+        self.query_file.filter_by.side_effect = handle_file_query
+
+        expected_result = file_not_changeable
+        actual_result = file.move(
+            {"device_uuid": mock_device.uuid,
+             "file_uuid": "my-file",
+             "new_filename": "new-name",
+             "new_parent_dir_uuid": "0"
+             }, "user"
+        )
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        mock_device.check_access.assert_called_with("user")
+
+    def test__user_endpoint__file_move__parent_directory_not_found(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_file = mock.MagicMock()
+        mock_file.is_changeable = True
+
+        self.query_device.get.return_value = mock_device
+
+        def handle_file_query(**kwargs):
+            out = mock.MagicMock()
+            if "new_filename" in kwargs:
+                self.assertEqual({
+                    "device": mock_device.uuid,
+                    "new_filename": "new-name",
+                    "new_parent_dir_uuid": "0"
+                }, kwargs)
+                out.first.return_value = None
+            elif "uuid" in kwargs and kwargs["uuid"] == "0":
+                self.assertEqual({"device": mock_device.uuid, "uuid": "0"}, kwargs)
+                out.first.return_value = None
+            else:
+                self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
+                out.first.return_value = mock_file
+            return out
+
+        self.query_file.filter_by.side_effect = handle_file_query
+
+        expected_result = parent_directory_not_found
+        actual_result = file.move(
+            {"device_uuid": mock_device.uuid,
+             "file_uuid": "my-file",
+             "new_filename": "new-name",
+             "new_parent_dir_uuid": "0"
+             }, "user"
+        )
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        mock_device.check_access.assert_called_with("user")
+
+    def test__user_endpoint__file_move__can_not_move_dir_into_itself(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_file = mock.MagicMock()
+        mock_file.is_changeable = True
+        mock_file.is_directory = True
+        mock_file.uuid = "3"
+        filesystem = {}
+        for i in range(0, 11):
+            dir_mock = mock.MagicMock()
+            dir_mock.parent_dir_uuid = str(i - 1)
+            dir_mock.uuid = str(i)
+            filesystem.update({str(i): dir_mock})
+        filesystem["0"].parent_dir_uuid = None
+
+        self.query_device.get.return_value = mock_device
+
+        def handle_file_query(**kwargs):
+            out = mock.MagicMock()
+            if "new_filename" in kwargs:
+                self.assertEqual({
+                    "device": mock_device.uuid,
+                    "new_filename": "new-name",
+                    "new_parent_dir_uuid": "10"
+                }, kwargs)
+                out.first.return_value = None
+            elif "uuid" in kwargs and kwargs["uuid"] == "my-file":
+                self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
+                out.first.return_value = mock_file
+            else:
+                self.assertEqual(mock_device.uuid, kwargs["device"])
+                self.assertIn(kwargs["uuid"], filesystem)
+                out.first.return_value = filesystem[kwargs["uuid"]]
+            return out
+
+        self.query_file.filter_by.side_effect = handle_file_query
+
+        expected_result = can_not_move_dir_into_itself
+        actual_result = file.move(
+            {"device_uuid": mock_device.uuid,
+             "file_uuid": "my-file",
+             "new_filename": "new-name",
+             "new_parent_dir_uuid": "10"
+             }, "user"
         )
 
         self.assertEqual(expected_result, actual_result)
@@ -202,24 +351,45 @@ class TestFile(TestCase):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
         mock_file = mock.MagicMock()
+        mock_file.is_changeable = True
+        mock_file.is_directory = True
+        mock_file.uuid = "3"
+        filesystem = {}
+        dir_mock = mock.MagicMock()
+        dir_mock.parent_dir_uuid = None
+        dir_mock.uuid = "0"
+        filesystem.update({str(0): dir_mock})
 
         self.query_device.get.return_value = mock_device
 
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
-            if "filename" in kwargs:
-                self.assertEqual({"device": mock_device.uuid, "filename": "new-name"}, kwargs)
+            if "new_filename" in kwargs:
+                self.assertEqual({
+                    "device": mock_device.uuid,
+                    "new_filename": "new-name",
+                    "new_parent_dir_uuid": "0"
+                }, kwargs)
                 out.first.return_value = None
-            else:
+            elif "uuid" in kwargs and kwargs["uuid"] == "my-file":
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
                 out.first.return_value = mock_file
+            else:
+                self.assertEqual(mock_device.uuid, kwargs["device"])
+                self.assertIn(kwargs["uuid"], filesystem)
+                out.first.return_value = filesystem[kwargs["uuid"]]
             return out
 
         self.query_file.filter_by.side_effect = handle_file_query
 
         expected_result = mock_file.serialize
         actual_result = file.move(
-            {"device_uuid": mock_device.uuid, "file_uuid": "my-file", "filename": "new-name"}, "user"
+            {
+                "device_uuid": mock_device.uuid,
+                "file_uuid": "my-file",
+                "new_filename": "new-name",
+                "new_parent_dir_uuid": "0"
+            }, "user"
         )
 
         self.assertEqual(expected_result, actual_result)
@@ -267,10 +437,51 @@ class TestFile(TestCase):
         mock_device.check_access.assert_called_with("user")
         self.query_file.filter_by.assert_called_with(device=mock_device.uuid, uuid="my-file")
 
+    def test__user_endpoint__file_update__directories_can_not_be_updated(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_file = mock.MagicMock()
+        mock_file.is_directory = True
+
+        self.query_device.get.return_value = mock_device
+        self.query_file.filter_by().first.return_value = mock_file
+
+        expected_result = directories_can_not_be_updated
+        actual_result = file.update(
+            {"device_uuid": mock_device.uuid, "file_uuid": "my-file", "content": "test"}, "user"
+        )
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        mock_device.check_access.assert_called_with("user")
+        self.query_file.filter_by.assert_called_with(device=mock_device.uuid, uuid="my-file")
+
+    def test__user_endpoint__file_update__file_not_changeable(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_file = mock.MagicMock()
+        mock_file.is_directory = False
+        mock_file.is_changeable = False
+
+        self.query_device.get.return_value = mock_device
+        self.query_file.filter_by().first.return_value = mock_file
+
+        expected_result = file_not_changeable
+        actual_result = file.update(
+            {"device_uuid": mock_device.uuid, "file_uuid": "my-file", "content": "test"}, "user"
+        )
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        mock_device.check_access.assert_called_with("user")
+        self.query_file.filter_by.assert_called_with(device=mock_device.uuid, uuid="my-file")
+
     def test__user_endpoint__file_update__successful(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
         mock_file = mock.MagicMock()
+        mock_file.is_directory = False
+        mock_file.is_changeable = True
 
         self.query_device.get.return_value = mock_device
         self.query_file.filter_by().first.return_value = mock_file
@@ -324,10 +535,29 @@ class TestFile(TestCase):
         mock_device.check_access.assert_called_with("user")
         self.query_file.filter_by.assert_called_with(device=mock_device.uuid, uuid="my-file")
 
-    def test__user_endpoint__file_delete__successful(self):
+    def test__user_endpoint__normal_file_delete__file_not_changeable(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
         mock_file = mock.MagicMock()
+        mock_file.is_changeable = False
+        mock_file.is_directory = False
+
+        self.query_device.get.return_value = mock_device
+        self.query_file.filter_by().first.return_value = mock_file
+
+        expected_result = file_not_changeable
+        actual_result = file.delete_file({"device_uuid": mock_device.uuid, "file_uuid": mock_file.uuid}, "user")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        mock_device.check_access.assert_called_with("user")
+        self.query_file.filter_by.assert_called_with(device=mock_device.uuid, uuid=mock_file.uuid)
+
+    def test__user_endpoint__normal_file_delete__successful(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_file = mock.MagicMock()
+        mock_file.is_directory = False
 
         self.query_device.get.return_value = mock_device
         self.query_file.filter_by().first.return_value = mock_file
@@ -341,6 +571,140 @@ class TestFile(TestCase):
         self.query_file.filter_by.assert_called_with(device=mock_device.uuid, uuid=mock_file.uuid)
         mock.wrapper.session.delete.assert_called_with(mock_file)
         mock.wrapper.session.commit.assert_called_with()
+
+    def test__user_endpoint__directory_file_delete__file_not_changeable(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_file = mock.MagicMock()
+        mock_file.is_changeable = True
+        mock_file.is_directory = True
+        mock_file.uuid = "AC"
+
+        filesystem = {}
+        filesystem_after_deletion = {}
+        def create_file(uuid, parent_dir_uuid, is_changeable, is_directory, add_to_filesystem_a_d):
+            file_mock = mock.MagicMock()
+            file_mock.uuid = uuid
+            file_mock.parent_dir_uuid = parent_dir_uuid
+            file_mock.is_changeable = is_changeable
+            file_mock.is_directory = is_directory
+            filesystem.update({uuid: file_mock})
+            if add_to_filesystem_a_d:
+                filesystem_after_deletion.update({uuid: file_mock})
+
+        create_file("0", None, False, True, True)
+        create_file("A", "0", True, True, True)
+        create_file("AA", "A", True, False, True)
+        create_file("AB", "A", True, False, True)
+        create_file("AC", "A", True, True, True)
+        create_file("AAA", "AC", True, True, False)
+        create_file("AAB", "AC", True, False, True)
+        create_file("AAC", "AC", False, False, True)
+        create_file("AAD", "AC", True, False, False)
+        create_file("AD", "A", True, False, True)
+        create_file("AE", "0", False, False, True)
+
+        self.query_device.get.return_value = mock_device
+
+        def handle_file_query(**kwargs):
+            out = mock.MagicMock()
+            if "uuid" in kwargs:
+                self.assertEqual({
+                    "device": mock_device.uuid,
+                    "uuid": "AC"
+                }, kwargs)
+                out.first.return_value = mock_file
+            elif "parent_dir_uuid" in kwargs:
+                self.assertIn(kwargs["parent_dir_uuid"], filesystem)
+                out.all.return_value = [v for _,v in filesystem.items() if v.parent_dir_uuid == kwargs["parent_dir_uuid"]]
+            return out
+
+        def delete_file(file):
+            del filesystem[file.uuid]
+
+        self.query_file.filter_by.side_effect = handle_file_query
+        mock.wrapper.session.delete.side_effect = delete_file
+        self.query_device.get.return_value = mock_device
+
+        expected_result = file_not_changeable
+        actual_result = file.delete_file(
+            {"device_uuid": mock_device.uuid,
+             "file_uuid": "AC"
+             }, "user"
+        )
+
+        self.assertEqual(expected_result, actual_result)
+        self.assertEqual(filesystem, filesystem_after_deletion)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        mock_device.check_access.assert_called_with("user")
+
+    def test__user_endpoint__directory_file_delete__successful(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_file = mock.MagicMock()
+        mock_file.is_changeable = True
+        mock_file.is_directory = True
+        mock_file.uuid = "AC"
+
+        filesystem = {}
+        filesystem_after_deletion = {}
+
+        def create_file(uuid, parent_dir_uuid, is_changeable, is_directory, add_to_filesystem_a_d):
+            file_mock = mock.MagicMock()
+            file_mock.uuid = uuid
+            file_mock.parent_dir_uuid = parent_dir_uuid
+            file_mock.is_changeable = is_changeable
+            file_mock.is_directory = is_directory
+            filesystem.update({uuid: file_mock})
+            if add_to_filesystem_a_d:
+                filesystem_after_deletion.update({uuid: file_mock})
+
+        create_file("0", None, False, True, True)
+        create_file("A", "0", True, True, True)
+        create_file("AA", "A", True, False, True)
+        create_file("AB", "A", True, False, True)
+        create_file("AC", "A", True, True, False)
+        create_file("AAA", "AC", True, True, False)
+        create_file("AAB", "AC", True, False, False)
+        create_file("AAC", "AC", True, False, False)
+        create_file("AAD", "AC", True, False, False)
+        create_file("AD", "A", True, False, True)
+        create_file("AE", "0", False, False, True)
+
+        self.query_device.get.return_value = mock_device
+
+        def handle_file_query(**kwargs):
+            out = mock.MagicMock()
+            if "uuid" in kwargs:
+                self.assertEqual({
+                    "device": mock_device.uuid,
+                    "uuid": "AC"
+                }, kwargs)
+                out.first.return_value = mock_file
+            elif "parent_dir_uuid" in kwargs:
+                self.assertIn(kwargs["parent_dir_uuid"], filesystem)
+                out.all.return_value = [v for _, v in filesystem.items() if
+                                        v.parent_dir_uuid == kwargs["parent_dir_uuid"]]
+            return out
+
+        def delete_file(file):
+            del filesystem[file.uuid]
+
+        self.query_file.filter_by.side_effect = handle_file_query
+        mock.wrapper.session.delete.side_effect = delete_file
+        self.query_device.get.return_value = mock_device
+
+        expected_result = success
+        actual_result = file.delete_file(
+            {"device_uuid": mock_device.uuid,
+             "file_uuid": "AC"
+             }, "user"
+        )
+
+        self.assertEqual(expected_result, actual_result)
+        self.assertEqual(filesystem, filesystem_after_deletion)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        mock_device.check_access.assert_called_with("user")
 
     def test__user_endpoint__file_create__device_not_found(self):
         self.query_device.get.return_value = None
@@ -373,14 +737,21 @@ class TestFile(TestCase):
 
         expected_result = file_already_exists
         actual_result = file.create_file(
-            {"device_uuid": mock_device.uuid, "filename": "test-file", "content": "some random content here"}, "user"
+            {"device_uuid": mock_device.uuid,
+             "filename": "test-file",
+             "content": "some random content here",
+             "parent_dir_uuid": "0",
+                "is_directory": False,
+                "is_changeable": True,
+             }, "user"
         )
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
         mock_device.check_access.assert_called_with("user")
         self.sqlalchemy_func.count.assert_called_with(File.uuid)
-        self.query_func_count.filter_by.assert_called_with(device=mock_device.uuid, filename="test-file")
+        self.query_func_count.filter_by.assert_called_with(device=mock_device.uuid, filename="test-file",
+                                                           parent_dir_uuid="0")
 
     @patch("resources.file.File.create")
     def test__user_endpoint__file_create__successful(self, file_create_patch):
@@ -392,12 +763,49 @@ class TestFile(TestCase):
 
         expected_result = file_create_patch().serialize
         actual_result = file.create_file(
-            {"device_uuid": mock_device.uuid, "filename": "test-file", "content": "some random content here"}, "user"
+            {
+                "device_uuid": mock_device.uuid,
+                "filename": "test-file",
+                "content": "some random content here",
+                "is_directory": False,
+                "is_changeable": True,
+                "parent_dir_uuid": "0"
+            }, "user"
         )
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
         mock_device.check_access.assert_called_with("user")
         self.sqlalchemy_func.count.assert_called_with(File.uuid)
-        self.query_func_count.filter_by.assert_called_with(device=mock_device.uuid, filename="test-file")
-        file_create_patch.assert_called_with(mock_device.uuid, "test-file", "some random content here")
+        self.query_func_count.filter_by.assert_called_with(device=mock_device.uuid, filename="test-file",
+                                                           parent_dir_uuid="0")
+        file_create_patch.assert_called_with(
+            mock_device.uuid, "test-file", "some random content here", "0", False, True
+        )
+
+    @patch("resources.file.File.create")
+    def test__user_endpoint__file_create__directory_can_not_have_textcontent(self, file_create_patch):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+
+        self.query_device.get.return_value = mock_device
+        self.query_func_count.filter_by().scalar.return_value = 0
+
+        expected_result = directory_can_not_have_textcontent
+        actual_result = file.create_file(
+            {
+                "device_uuid": mock_device.uuid,
+                "filename": "test-file",
+                "content": "some random content here",
+                "is_changeable": True,
+                "is_directory": True,
+                "parent_dir_uuid": "0"
+            }, "user"
+        )
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        mock_device.check_access.assert_called_with("user")
+        self.sqlalchemy_func.count.assert_called_with(File.uuid)
+        self.query_func_count.filter_by.assert_called_with(device=mock_device.uuid, filename="test-file",
+                                                           parent_dir_uuid="0")

--- a/app/tests/test_file.py
+++ b/app/tests/test_file.py
@@ -195,9 +195,7 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "filename" in kwargs:
-                self.assertEqual(
-                    {"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "0"}, kwargs
-                )
+                self.assertEqual({"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "0"}, kwargs)
                 out.first.return_value = mock.MagicMock()
             else:
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
@@ -267,9 +265,7 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "filename" in kwargs:
-                self.assertEqual(
-                    {"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "0"}, kwargs
-                )
+                self.assertEqual({"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "0"}, kwargs)
                 out.first.return_value = None
             elif "uuid" in kwargs and kwargs["uuid"] == "0":
                 self.assertEqual({"device": mock_device.uuid, "uuid": "0", "is_directory": True}, kwargs)
@@ -316,9 +312,7 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "filename" in kwargs:
-                self.assertEqual(
-                    {"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "10"}, kwargs
-                )
+                self.assertEqual({"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "10"}, kwargs)
                 out.first.return_value = None
             elif "uuid" in kwargs and kwargs["uuid"] == "my-file":
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
@@ -364,9 +358,7 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "filename" in kwargs:
-                self.assertEqual(
-                    {"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "0"}, kwargs
-                )
+                self.assertEqual({"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "0"}, kwargs)
                 out.first.return_value = None
             elif "uuid" in kwargs and kwargs["uuid"] == "my-file":
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)

--- a/app/tests/test_file.py
+++ b/app/tests/test_file.py
@@ -118,7 +118,12 @@ class TestFile(TestCase):
         self.query_device.get.return_value = None
 
         expected_result = device_not_found
-        actual_result = file.move({"device_uuid": "my-device", "file_uuid": "my-file", "filename": "new-name"}, "user")
+        actual_result = file.move({
+            "device_uuid": "my-device",
+            "file_uuid": "my-file",
+            "filename": "new-name",
+            "parent_dir_uuid": "0"
+        }, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -130,7 +135,12 @@ class TestFile(TestCase):
         self.query_device.get.return_value = mock_device
 
         expected_result = permission_denied
-        actual_result = file.move({"device_uuid": "my-device", "file_uuid": "my-file", "filename": "new-name"}, "user")
+        actual_result = file.move({
+            "device_uuid": "my-device",
+            "file_uuid": "my-file",
+            "filename": "new-name",
+            "parent_dir_uuid": "0"
+        }, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -144,8 +154,12 @@ class TestFile(TestCase):
         self.query_file.filter_by().first.return_value = None
 
         expected_result = file_not_found
-        actual_result = file.move(
-            {"device_uuid": mock_device.uuid, "file_uuid": "my-file", "filename": "new-name"}, "user"
+        actual_result = file.move({
+            "device_uuid": mock_device.uuid,
+            "file_uuid": "my-file",
+            "filename": "new-name",
+            "parent_dir_uuid": "0"
+        }, "user"
         )
 
         self.assertEqual(expected_result, actual_result)
@@ -163,7 +177,10 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "filename" in kwargs:
-                self.assertEqual({"device": mock_device.uuid, "filename": "new-name"}, kwargs)
+                self.assertEqual({
+                    "device": mock_device.uuid,
+                    "filename": "new-name"
+                }, kwargs)
                 out.first.return_value = mock.MagicMock()
             else:
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)

--- a/app/tests/test_file.py
+++ b/app/tests/test_file.py
@@ -16,7 +16,6 @@ from schemes import (
     parent_directory_not_found,
     can_not_move_dir_into_itself,
     directory_can_not_have_textcontent,
-    parent_dir_does_not_exist,
 )
 
 
@@ -807,7 +806,7 @@ class TestFile(TestCase):
         self.query_device.get.return_value = mock_device
         self.query_func_count.filter_by().scalar.return_value = 0
 
-        expected_result = parent_dir_does_not_exist
+        expected_result = parent_directory_not_found
         actual_result = file.create_file(
             {
                 "device_uuid": mock_device.uuid,

--- a/app/tests/test_file.py
+++ b/app/tests/test_file.py
@@ -387,6 +387,15 @@ class TestFile(TestCase):
         mock_device.check_access.assert_called_with("user")
         self.assertEqual("new-name", mock_file.filename)
         mock.wrapper.session.commit.assert_called_with()
+        mock.m.contact_user.assert_called_with(
+            "user",
+            {
+                "notify-id": "file-update",
+                "origin": "update",
+                "device_uuid": mock_device.uuid,
+                "data": {"created": [], "deleted": [], "changed": [mock_file.uuid]},
+            },
+        )
 
     def test__user_endpoint__file_update__device_not_found(self):
         self.query_device.get.return_value = None
@@ -487,6 +496,15 @@ class TestFile(TestCase):
         self.query_file.filter_by.assert_called_with(device=mock_device.uuid, uuid=mock_file.uuid)
         self.assertEqual("test", mock_file.content)
         mock.wrapper.session.commit.assert_called_with()
+        mock.m.contact_user.assert_called_with(
+            "user",
+            {
+                "notify-id": "file-update",
+                "origin": "update",
+                "device_uuid": mock_device.uuid,
+                "data": {"created": [], "deleted": [], "changed": [mock_file.uuid]},
+            },
+        )
 
     def test__user_endpoint__file_delete__device_not_found(self):
         self.query_device.get.return_value = None
@@ -623,6 +641,15 @@ class TestFile(TestCase):
         self.assertEqual(filesystem, filesystem_after_deletion)
         self.query_device.get.assert_called_with(mock_device.uuid)
         mock_device.check_access.assert_called_with("user")
+        mock.m.contact_user.assert_called_with(
+            "user",
+            {
+                "notify-id": "file-update",
+                "origin": "delete",
+                "device_uuid": mock_device.uuid,
+                "data": {"created": [], "deleted": ["AAA", "AAD"], "changed": []},
+            },
+        )
 
     def test__user_endpoint__directory_file_delete__successful(self):
         mock_device = mock.MagicMock()
@@ -685,6 +712,15 @@ class TestFile(TestCase):
         self.assertEqual(filesystem, filesystem_after_deletion)
         self.query_device.get.assert_called_with(mock_device.uuid)
         mock_device.check_access.assert_called_with("user")
+        mock.m.contact_user.assert_called_with(
+            "user",
+            {
+                "notify-id": "file-update",
+                "origin": "delete",
+                "device_uuid": mock_device.uuid,
+                "data": {"created": [], "deleted": ["AAA", "AAD", "AAC", "AAB", "AC"], "changed": []},
+            },
+        )
 
     def test__user_endpoint__file_create__device_not_found(self):
         self.query_device.get.return_value = None
@@ -766,6 +802,15 @@ class TestFile(TestCase):
         )
         file_create_patch.assert_called_with(
             mock_device.uuid, "test-file", "some random content here", "0", False, True
+        )
+        mock.m.contact_user.assert_called_with(
+            "user",
+            {
+                "notify-id": "file-update",
+                "origin": "create",
+                "device_uuid": mock_device.uuid,
+                "data": {"created": [file_create_patch().uuid], "deleted": [], "changed": []},
+            },
         )
 
     @patch("resources.file.File.create")

--- a/app/tests/test_file.py
+++ b/app/tests/test_file.py
@@ -194,9 +194,9 @@ class TestFile(TestCase):
 
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
-            if "new_filename" in kwargs:
+            if "filename" in kwargs:
                 self.assertEqual(
-                    {"device": mock_device.uuid, "new_filename": "new-name", "new_parent_dir_uuid": "0"}, kwargs
+                    {"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "0"}, kwargs
                 )
                 out.first.return_value = mock.MagicMock()
             else:
@@ -231,8 +231,8 @@ class TestFile(TestCase):
 
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
-            if "new_filename" in kwargs:
-                self.assertEqual({"device": mock_device.uuid, "new_filename": "new-name"}, kwargs)
+            if "filename" in kwargs:
+                self.assertEqual({"device": mock_device.uuid, "filename": "new-name"}, kwargs)
                 out.first.return_value = None
             else:
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
@@ -266,13 +266,13 @@ class TestFile(TestCase):
 
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
-            if "new_filename" in kwargs:
+            if "filename" in kwargs:
                 self.assertEqual(
-                    {"device": mock_device.uuid, "new_filename": "new-name", "new_parent_dir_uuid": "0"}, kwargs
+                    {"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "0"}, kwargs
                 )
                 out.first.return_value = None
             elif "uuid" in kwargs and kwargs["uuid"] == "0":
-                self.assertEqual({"device": mock_device.uuid, "uuid": "0"}, kwargs)
+                self.assertEqual({"device": mock_device.uuid, "uuid": "0", "is_directory": True}, kwargs)
                 out.first.return_value = None
             else:
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
@@ -315,9 +315,9 @@ class TestFile(TestCase):
 
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
-            if "new_filename" in kwargs:
+            if "filename" in kwargs:
                 self.assertEqual(
-                    {"device": mock_device.uuid, "new_filename": "new-name", "new_parent_dir_uuid": "10"}, kwargs
+                    {"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "10"}, kwargs
                 )
                 out.first.return_value = None
             elif "uuid" in kwargs and kwargs["uuid"] == "my-file":
@@ -363,9 +363,9 @@ class TestFile(TestCase):
 
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
-            if "new_filename" in kwargs:
+            if "filename" in kwargs:
                 self.assertEqual(
-                    {"device": mock_device.uuid, "new_filename": "new-name", "new_parent_dir_uuid": "0"}, kwargs
+                    {"device": mock_device.uuid, "filename": "new-name", "parent_dir_uuid": "0"}, kwargs
                 )
                 out.first.return_value = None
             elif "uuid" in kwargs and kwargs["uuid"] == "my-file":

--- a/app/tests/test_file.py
+++ b/app/tests/test_file.py
@@ -75,8 +75,7 @@ class TestFile(TestCase):
         self.query_device.get.return_value = None
 
         expected_result = device_not_found
-        actual_result = file.file_info({"device_uuid": "my-device", "file_uuid": "my-file"},
-                                       "user")
+        actual_result = file.file_info({"device_uuid": "my-device", "file_uuid": "my-file"}, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -88,11 +87,7 @@ class TestFile(TestCase):
         self.query_device.get.return_value = mock_device
 
         expected_result = permission_denied
-        actual_result = file.file_info({
-            "device_uuid": "my-device",
-            "file_uuid": "my-file"
-        },
-            "user")
+        actual_result = file.file_info({"device_uuid": "my-device", "file_uuid": "my-file"}, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -106,10 +101,7 @@ class TestFile(TestCase):
         self.query_file.filter_by().first.return_value = None
 
         expected_result = file_not_found
-        actual_result = file.file_info({
-            "device_uuid": mock_device.uuid,
-            "file_uuid": "my-file"
-        }, "user")
+        actual_result = file.file_info({"device_uuid": mock_device.uuid, "file_uuid": "my-file"}, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
@@ -125,10 +117,7 @@ class TestFile(TestCase):
         self.query_file.filter_by().first.return_value = mock_file
 
         expected_result = mock_file.serialize
-        actual_result = file.file_info({
-            "device_uuid": mock_device.uuid,
-            "file_uuid": mock_file.uuid
-        }, "user")
+        actual_result = file.file_info({"device_uuid": mock_device.uuid, "file_uuid": mock_file.uuid}, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
@@ -139,12 +128,15 @@ class TestFile(TestCase):
         self.query_device.get.return_value = None
 
         expected_result = device_not_found
-        actual_result = file.move({
-            "device_uuid": "my-device",
-            "file_uuid": "my-file",
-            "new_filename": "new-name",
-            "new_parent_dir_uuid": "0"
-        }, "user")
+        actual_result = file.move(
+            {
+                "device_uuid": "my-device",
+                "file_uuid": "my-file",
+                "new_filename": "new-name",
+                "new_parent_dir_uuid": "0",
+            },
+            "user",
+        )
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -156,12 +148,15 @@ class TestFile(TestCase):
         self.query_device.get.return_value = mock_device
 
         expected_result = permission_denied
-        actual_result = file.move({
-            "device_uuid": "my-device",
-            "file_uuid": "my-file",
-            "new_filename": "new-name",
-            "new_parent_dir_uuid": "0"
-        }, "user")
+        actual_result = file.move(
+            {
+                "device_uuid": "my-device",
+                "file_uuid": "my-file",
+                "new_filename": "new-name",
+                "new_parent_dir_uuid": "0",
+            },
+            "user",
+        )
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my-device")
@@ -175,12 +170,14 @@ class TestFile(TestCase):
         self.query_file.filter_by().first.return_value = None
 
         expected_result = file_not_found
-        actual_result = file.move({
-            "device_uuid": mock_device.uuid,
-            "file_uuid": "my-file",
-            "new_filename": "new-name",
-            "new_parent_dir_uuid": "0"
-        }, "user"
+        actual_result = file.move(
+            {
+                "device_uuid": mock_device.uuid,
+                "file_uuid": "my-file",
+                "new_filename": "new-name",
+                "new_parent_dir_uuid": "0",
+            },
+            "user",
         )
 
         self.assertEqual(expected_result, actual_result)
@@ -198,11 +195,9 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "new_filename" in kwargs:
-                self.assertEqual({
-                    "device": mock_device.uuid,
-                    "new_filename": "new-name",
-                    "new_parent_dir_uuid": "0"
-                }, kwargs)
+                self.assertEqual(
+                    {"device": mock_device.uuid, "new_filename": "new-name", "new_parent_dir_uuid": "0"}, kwargs
+                )
                 out.first.return_value = mock.MagicMock()
             else:
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
@@ -213,11 +208,13 @@ class TestFile(TestCase):
 
         expected_result = file_already_exists
         actual_result = file.move(
-            {"device_uuid": mock_device.uuid,
-             "file_uuid": "my-file",
-             "new_filename": "new-name",
-             "new_parent_dir_uuid": "0"
-             }, "user"
+            {
+                "device_uuid": mock_device.uuid,
+                "file_uuid": "my-file",
+                "new_filename": "new-name",
+                "new_parent_dir_uuid": "0",
+            },
+            "user",
         )
 
         self.assertEqual(expected_result, actual_result)
@@ -246,11 +243,13 @@ class TestFile(TestCase):
 
         expected_result = file_not_changeable
         actual_result = file.move(
-            {"device_uuid": mock_device.uuid,
-             "file_uuid": "my-file",
-             "new_filename": "new-name",
-             "new_parent_dir_uuid": "0"
-             }, "user"
+            {
+                "device_uuid": mock_device.uuid,
+                "file_uuid": "my-file",
+                "new_filename": "new-name",
+                "new_parent_dir_uuid": "0",
+            },
+            "user",
         )
 
         self.assertEqual(expected_result, actual_result)
@@ -268,11 +267,9 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "new_filename" in kwargs:
-                self.assertEqual({
-                    "device": mock_device.uuid,
-                    "new_filename": "new-name",
-                    "new_parent_dir_uuid": "0"
-                }, kwargs)
+                self.assertEqual(
+                    {"device": mock_device.uuid, "new_filename": "new-name", "new_parent_dir_uuid": "0"}, kwargs
+                )
                 out.first.return_value = None
             elif "uuid" in kwargs and kwargs["uuid"] == "0":
                 self.assertEqual({"device": mock_device.uuid, "uuid": "0"}, kwargs)
@@ -286,11 +283,13 @@ class TestFile(TestCase):
 
         expected_result = parent_directory_not_found
         actual_result = file.move(
-            {"device_uuid": mock_device.uuid,
-             "file_uuid": "my-file",
-             "new_filename": "new-name",
-             "new_parent_dir_uuid": "0"
-             }, "user"
+            {
+                "device_uuid": mock_device.uuid,
+                "file_uuid": "my-file",
+                "new_filename": "new-name",
+                "new_parent_dir_uuid": "0",
+            },
+            "user",
         )
 
         self.assertEqual(expected_result, actual_result)
@@ -317,11 +316,9 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "new_filename" in kwargs:
-                self.assertEqual({
-                    "device": mock_device.uuid,
-                    "new_filename": "new-name",
-                    "new_parent_dir_uuid": "10"
-                }, kwargs)
+                self.assertEqual(
+                    {"device": mock_device.uuid, "new_filename": "new-name", "new_parent_dir_uuid": "10"}, kwargs
+                )
                 out.first.return_value = None
             elif "uuid" in kwargs and kwargs["uuid"] == "my-file":
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
@@ -336,11 +333,13 @@ class TestFile(TestCase):
 
         expected_result = can_not_move_dir_into_itself
         actual_result = file.move(
-            {"device_uuid": mock_device.uuid,
-             "file_uuid": "my-file",
-             "new_filename": "new-name",
-             "new_parent_dir_uuid": "10"
-             }, "user"
+            {
+                "device_uuid": mock_device.uuid,
+                "file_uuid": "my-file",
+                "new_filename": "new-name",
+                "new_parent_dir_uuid": "10",
+            },
+            "user",
         )
 
         self.assertEqual(expected_result, actual_result)
@@ -365,11 +364,9 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "new_filename" in kwargs:
-                self.assertEqual({
-                    "device": mock_device.uuid,
-                    "new_filename": "new-name",
-                    "new_parent_dir_uuid": "0"
-                }, kwargs)
+                self.assertEqual(
+                    {"device": mock_device.uuid, "new_filename": "new-name", "new_parent_dir_uuid": "0"}, kwargs
+                )
                 out.first.return_value = None
             elif "uuid" in kwargs and kwargs["uuid"] == "my-file":
                 self.assertEqual({"device": mock_device.uuid, "uuid": "my-file"}, kwargs)
@@ -388,8 +385,9 @@ class TestFile(TestCase):
                 "device_uuid": mock_device.uuid,
                 "file_uuid": "my-file",
                 "new_filename": "new-name",
-                "new_parent_dir_uuid": "0"
-            }, "user"
+                "new_parent_dir_uuid": "0",
+            },
+            "user",
         )
 
         self.assertEqual(expected_result, actual_result)
@@ -582,6 +580,7 @@ class TestFile(TestCase):
 
         filesystem = {}
         filesystem_after_deletion = {}
+
         def create_file(uuid, parent_dir_uuid, is_changeable, is_directory, add_to_filesystem_a_d):
             file_mock = mock.MagicMock()
             file_mock.uuid = uuid
@@ -609,14 +608,13 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "uuid" in kwargs:
-                self.assertEqual({
-                    "device": mock_device.uuid,
-                    "uuid": "AC"
-                }, kwargs)
+                self.assertEqual({"device": mock_device.uuid, "uuid": "AC"}, kwargs)
                 out.first.return_value = mock_file
             elif "parent_dir_uuid" in kwargs:
                 self.assertIn(kwargs["parent_dir_uuid"], filesystem)
-                out.all.return_value = [v for _,v in filesystem.items() if v.parent_dir_uuid == kwargs["parent_dir_uuid"]]
+                out.all.return_value = [
+                    v for _, v in filesystem.items() if v.parent_dir_uuid == kwargs["parent_dir_uuid"]
+                ]
             return out
 
         def delete_file(file):
@@ -627,11 +625,7 @@ class TestFile(TestCase):
         self.query_device.get.return_value = mock_device
 
         expected_result = file_not_changeable
-        actual_result = file.delete_file(
-            {"device_uuid": mock_device.uuid,
-             "file_uuid": "AC"
-             }, "user"
-        )
+        actual_result = file.delete_file({"device_uuid": mock_device.uuid, "file_uuid": "AC"}, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.assertEqual(filesystem, filesystem_after_deletion)
@@ -676,15 +670,13 @@ class TestFile(TestCase):
         def handle_file_query(**kwargs):
             out = mock.MagicMock()
             if "uuid" in kwargs:
-                self.assertEqual({
-                    "device": mock_device.uuid,
-                    "uuid": "AC"
-                }, kwargs)
+                self.assertEqual({"device": mock_device.uuid, "uuid": "AC"}, kwargs)
                 out.first.return_value = mock_file
             elif "parent_dir_uuid" in kwargs:
                 self.assertIn(kwargs["parent_dir_uuid"], filesystem)
-                out.all.return_value = [v for _, v in filesystem.items() if
-                                        v.parent_dir_uuid == kwargs["parent_dir_uuid"]]
+                out.all.return_value = [
+                    v for _, v in filesystem.items() if v.parent_dir_uuid == kwargs["parent_dir_uuid"]
+                ]
             return out
 
         def delete_file(file):
@@ -695,11 +687,7 @@ class TestFile(TestCase):
         self.query_device.get.return_value = mock_device
 
         expected_result = success
-        actual_result = file.delete_file(
-            {"device_uuid": mock_device.uuid,
-             "file_uuid": "AC"
-             }, "user"
-        )
+        actual_result = file.delete_file({"device_uuid": mock_device.uuid, "file_uuid": "AC"}, "user")
 
         self.assertEqual(expected_result, actual_result)
         self.assertEqual(filesystem, filesystem_after_deletion)
@@ -737,21 +725,24 @@ class TestFile(TestCase):
 
         expected_result = file_already_exists
         actual_result = file.create_file(
-            {"device_uuid": mock_device.uuid,
-             "filename": "test-file",
-             "content": "some random content here",
-             "parent_dir_uuid": "0",
+            {
+                "device_uuid": mock_device.uuid,
+                "filename": "test-file",
+                "content": "some random content here",
+                "parent_dir_uuid": "0",
                 "is_directory": False,
                 "is_changeable": True,
-             }, "user"
+            },
+            "user",
         )
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
         mock_device.check_access.assert_called_with("user")
         self.sqlalchemy_func.count.assert_called_with(File.uuid)
-        self.query_func_count.filter_by.assert_called_with(device=mock_device.uuid, filename="test-file",
-                                                           parent_dir_uuid="0")
+        self.query_func_count.filter_by.assert_called_with(
+            device=mock_device.uuid, filename="test-file", parent_dir_uuid="0"
+        )
 
     @patch("resources.file.File.create")
     def test__user_endpoint__file_create__successful(self, file_create_patch):
@@ -769,16 +760,18 @@ class TestFile(TestCase):
                 "content": "some random content here",
                 "is_directory": False,
                 "is_changeable": True,
-                "parent_dir_uuid": "0"
-            }, "user"
+                "parent_dir_uuid": "0",
+            },
+            "user",
         )
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
         mock_device.check_access.assert_called_with("user")
         self.sqlalchemy_func.count.assert_called_with(File.uuid)
-        self.query_func_count.filter_by.assert_called_with(device=mock_device.uuid, filename="test-file",
-                                                           parent_dir_uuid="0")
+        self.query_func_count.filter_by.assert_called_with(
+            device=mock_device.uuid, filename="test-file", parent_dir_uuid="0"
+        )
         file_create_patch.assert_called_with(
             mock_device.uuid, "test-file", "some random content here", "0", False, True
         )
@@ -799,13 +792,15 @@ class TestFile(TestCase):
                 "content": "some random content here",
                 "is_changeable": True,
                 "is_directory": True,
-                "parent_dir_uuid": "0"
-            }, "user"
+                "parent_dir_uuid": "0",
+            },
+            "user",
         )
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with(mock_device.uuid)
         mock_device.check_access.assert_called_with("user")
         self.sqlalchemy_func.count.assert_called_with(File.uuid)
-        self.query_func_count.filter_by.assert_called_with(device=mock_device.uuid, filename="test-file",
-                                                           parent_dir_uuid="0")
+        self.query_func_count.filter_by.assert_called_with(
+            device=mock_device.uuid, filename="test-file", parent_dir_uuid="0"
+        )

--- a/app/tests/test_file_model.py
+++ b/app/tests/test_file_model.py
@@ -11,17 +11,28 @@ class TestFileModel(TestCase):
     def test__model__file__structure(self):
         self.assertEqual("device_file", File.__tablename__)
         self.assertTrue(issubclass(File, mock.wrapper.Base))
-        for col in ["uuid", "device", "filename", "content"]:
+        for col in ["uuid", "device", "filename", "content", "is_directory", "parent_dir_uuid", "is_changeable"]:
             self.assertIn(col, dir(File))
 
     def test__model__file__serialize(self):
-        file = File(uuid="file identifier", device="the device", filename="some_file.txt", content="hello world")
+        file = File(
+            uuid="file identifier",
+            device="the device",
+            filename="some_file.txt",
+            content="hello world",
+            parent_dir_uuid="some_other_identifier",
+            is_directory=False,
+            is_changeable=False
+        )
 
         expected_result = {
             "uuid": "file identifier",
             "device": "the device",
             "filename": "some_file.txt",
             "content": "hello world",
+            "parent_dir_uuid": "some_other_identifier",
+            "is_directory": False,
+            "is_changeable": False
         }
         serialized = file.serialize
 
@@ -31,16 +42,18 @@ class TestFileModel(TestCase):
         self.assertEqual(expected_result, file.serialize)
 
     def test__model__file__create(self):
-        actual_result = File.create("my-device", "foo.bar", "super")
+        actual_result = File.create("my-device", "foo.bar", "super", "baz", False, True)
 
         self.assertEqual("my-device", actual_result.device)
         self.assertEqual("foo.bar", actual_result.filename)
-        self.assertEqual("super", actual_result.content)
+        self.assertEqual("baz", actual_result.parent_dir_uuid)
+        self.assertEqual(False, actual_result.is_directory)
+        self.assertEqual(True, actual_result.is_changeable)
         self.assertRegex(actual_result.uuid, r"[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}")
         mock.wrapper.session.add.assert_called_with(actual_result)
         mock.wrapper.session.commit.assert_called_with()
 
     def test__model__device__create__different_uuid(self):
-        first_element = File.create("device", "foo.bar", "super").uuid
-        second_element = File.create("device", "foo.bar", "super").uuid
+        first_element = File.create("device", "foo.bar", "super", "baz", False, True).uuid
+        second_element = File.create("device", "foo.bar", "super", "baz", False, True).uuid
         self.assertNotEqual(first_element, second_element)

--- a/app/tests/test_file_model.py
+++ b/app/tests/test_file_model.py
@@ -22,7 +22,7 @@ class TestFileModel(TestCase):
             content="hello world",
             parent_dir_uuid="some_other_identifier",
             is_directory=False,
-            is_changeable=False
+            is_changeable=False,
         )
 
         expected_result = {
@@ -32,7 +32,7 @@ class TestFileModel(TestCase):
             "content": "hello world",
             "parent_dir_uuid": "some_other_identifier",
             "is_directory": False,
-            "is_changeable": False
+            "is_changeable": False,
         }
         serialized = file.serialize
 

--- a/app/tests/test_file_model.py
+++ b/app/tests/test_file_model.py
@@ -11,7 +11,7 @@ class TestFileModel(TestCase):
     def test__model__file__structure(self):
         self.assertEqual("device_file", File.__tablename__)
         self.assertTrue(issubclass(File, mock.wrapper.Base))
-        for col in ["uuid", "device", "filename", "content", "is_directory", "parent_dir_uuid", "is_changeable"]:
+        for col in ["uuid", "device", "filename", "content", "is_directory", "parent_dir_uuid"]:
             self.assertIn(col, dir(File))
 
     def test__model__file__serialize(self):
@@ -42,18 +42,17 @@ class TestFileModel(TestCase):
         self.assertEqual(expected_result, file.serialize)
 
     def test__model__file__create(self):
-        actual_result = File.create("my-device", "foo.bar", "super", "baz", False, True)
+        actual_result = File.create("my-device", "foo.bar", "super", "baz", False)
 
         self.assertEqual("my-device", actual_result.device)
         self.assertEqual("foo.bar", actual_result.filename)
         self.assertEqual("baz", actual_result.parent_dir_uuid)
         self.assertEqual(False, actual_result.is_directory)
-        self.assertEqual(True, actual_result.is_changeable)
         self.assertRegex(actual_result.uuid, r"[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}")
         mock.wrapper.session.add.assert_called_with(actual_result)
         mock.wrapper.session.commit.assert_called_with()
 
     def test__model__device__create__different_uuid(self):
-        first_element = File.create("device", "foo.bar", "super", "baz", False, True).uuid
-        second_element = File.create("device", "foo.bar", "super", "baz", False, True).uuid
+        first_element = File.create("device", "foo.bar", "super", "baz", False).uuid
+        second_element = File.create("device", "foo.bar", "super", "baz", False).uuid
         self.assertNotEqual(first_element, second_element)

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -62,7 +62,8 @@ class TestApp(TestCase):
         registered_user_endpoints = mock.user_endpoints.copy()
         registered_ms_endpoints = mock.ms_endpoints.copy()
 
-        file_errors = (device_exists, can_access_device, device_powered_on)
+        device_reachable = (device_exists, can_access_device, device_powered_on)
+        file_errors = (*device_reachable, file_exists)
         expected_user_endpoints = [
             (["device", "info"], requirement_device, device.device_info, device_exists),
             (["device", "ping"], requirement_device, device.ping, device_exists),
@@ -70,15 +71,15 @@ class TestApp(TestCase):
             (["device", "create"], requirement_build, device.create_device),
             (["device", "starter_device"], {}, device.starter_device),
             (["device", "power"], requirement_device, device.power, device_exists, can_access_device),
-            (["device", "change_name"], requirement_change_name, device.change_name, *file_errors),
+            (["device", "change_name"], requirement_change_name, device.change_name, *device_reachable),
             (["device", "delete"], requirement_device, device.delete_device, device_exists),
             (["device", "spot"], {}, device.spot),
-            (["file", "all"], basic_file_requirement, file.list_files, *file_errors),
-            (["file", "info"], requirement_file, file.file_info, *file_errors, file_exists),
-            (["file", "move"], requirement_file_move, file.move, *file_errors, file_exists),
-            (["file", "update"], requirement_file_update, file.update, *file_errors, file_exists),
-            (["file", "delete"], requirement_file_delete, file.delete_file, *file_errors, file_exists),
-            (["file", "create"], requirement_file_create, file.create_file, *file_errors),
+            (["file", "all"], basic_file_requirement, file.list_files, *device_reachable),
+            (["file", "info"], requirement_file, file.file_info, *file_errors),
+            (["file", "move"], requirement_file_move, file.move, *file_errors),
+            (["file", "update"], requirement_file_update, file.update, *file_errors),
+            (["file", "delete"], requirement_file_delete, file.delete_file, *file_errors),
+            (["file", "create"], requirement_file_create, file.create_file, *device_reachable),
             (["hardware", "build"], requirement_build, hardware.build),
             (["hardware", "resources"], requirement_device, hardware.hardware_resources),
             (["hardware", "process"], requirement_service, hardware.hardware_process),

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -13,6 +13,7 @@ from schemes import (
     requirement_file_create,
     requirement_service,
     requirement_file_delete,
+    basic_file_requirement,
 )
 
 
@@ -73,7 +74,7 @@ class TestApp(TestCase):
             (["device", "change_name"], requirement_change_name, device.change_name),
             (["device", "delete"], requirement_device, device.delete_device),
             (["device", "spot"], {}, device.spot),
-            (["file", "all"], requirement_device, file.list_files),
+            (["file", "all"], basic_file_requirement, file.list_files),
             (["file", "info"], requirement_file, file.file_info),
             (["file", "move"], requirement_file_move, file.move),
             (["file", "update"], requirement_file_update, file.update),

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from mock.mock_loader import mock
 from resources import device, file, hardware
-from resources.errors import device_exists, can_access_device, device_powered_on
+from resources.errors import device_exists, can_access_device, device_powered_on, file_exists
 from schemes import (
     requirement_device,
     requirement_build,
@@ -74,10 +74,10 @@ class TestApp(TestCase):
             (["device", "delete"], requirement_device, device.delete_device, device_exists),
             (["device", "spot"], {}, device.spot),
             (["file", "all"], basic_file_requirement, file.list_files, *file_errors),
-            (["file", "info"], requirement_file, file.file_info, *file_errors),
-            (["file", "move"], requirement_file_move, file.move, *file_errors),
-            (["file", "update"], requirement_file_update, file.update, *file_errors),
-            (["file", "delete"], requirement_file_delete, file.delete_file, *file_errors),
+            (["file", "info"], requirement_file, file.file_info, *file_errors, file_exists),
+            (["file", "move"], requirement_file_move, file.move, *file_errors, file_exists),
+            (["file", "update"], requirement_file_update, file.update, *file_errors, file_exists),
+            (["file", "delete"], requirement_file_delete, file.delete_file, *file_errors, file_exists),
             (["file", "create"], requirement_file_create, file.create_file, *file_errors),
             (["hardware", "build"], requirement_build, hardware.build),
             (["hardware", "resources"], requirement_device, hardware.hardware_resources),

--- a/sonar-scanner.sh
+++ b/sonar-scanner.sh
@@ -10,4 +10,4 @@ rm $HOME/.sonar/sonar-scanner.zip
 export PATH=$SONAR_SCANNER_HOME/bin:$PATH
 export SONAR_SCANNER_OPTS="-server"
 
-sonar-scanner -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
+sonar-scanner -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -X


### PR DESCRIPTION
## Description
- implemented directories ("is_directory" is used to indicated if a file is a directory)
- added "parent_dir_uuid" to link to the parrent directory of the file 
- added boolean changeable to File, to prevent "/" file from being moved or deleted
- device creation also creates "/"
- directories can no longer moved inside itself or its child directories
- not changeable files can no longer be changed

## Related Issue
#46 

## Motivation and Context
Now there are directories not only files

## How Has This Been Tested?
not yet tested, unit tests will follow

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
