### PR TITLE
part owner can delete devices

### DIFF
--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -198,7 +198,7 @@ def delete_device(data: dict, user: str) -> dict:
     if device is None:
         return device_not_found
 
-    if not device.check_access(user):
+    if device.owner != user:
         return permission_denied
 
     stop_all_service(data["device_uuid"], delete=True)

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -265,7 +265,7 @@ class TestDevice(TestCase):
 
     def test__user_endpoint__device_delete__permission_denied(self):
         mock_device = mock.MagicMock()
-        mock_device.check_access.return_value = False
+        mock_device.owner = "other-user"
         self.query_device.get.return_value = mock_device
 
         expected_result = permission_denied
@@ -273,13 +273,12 @@ class TestDevice(TestCase):
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("the-device")
-        mock_device.check_access.assert_called_with("user")
 
     @patch("resources.device.delete_services")
     @patch("resources.device.stop_all_service")
     def test__user_endpoint__device_delete__successful(self, sas_patch, ds_patch):
         mock_device = mock.MagicMock()
-        mock_device.check_access.return_value = True
+        mock_device.owner = "user"
         self.query_device.get.return_value = mock_device
 
         expected_result = success
@@ -287,7 +286,6 @@ class TestDevice(TestCase):
 
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("the-device")
-        mock_device.check_access.assert_called_with("user")
         sas_patch.assert_called_with("the-device", delete=True)
         ds_patch.assert_called_with("the-device")
         mock.wrapper.session.delete.assert_called_with(mock_device)


### PR DESCRIPTION
## Description
Fixed permission check in `/device/delete` endpoint to prevent part owners from deleting devices remotely.

## Related Issue
#67 

## How Has This Been Tested?
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
