### PR TITLE
do not allow interaction with powered off devices

### DIFF
--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -27,6 +27,7 @@ from schemes import (
     requirement_change_name,
     already_own_a_device,
     maximum_devices_reached,
+    device_powered_off,
 )
 from vars import hardware
 
@@ -182,6 +183,9 @@ def change_name(data: dict, user: str) -> dict:
 
     if not device.check_access(user):
         return permission_denied
+
+    if not device.powered_on:
+        return device_powered_off
 
     name: str = str(data["name"])
 

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -242,6 +242,16 @@ def exist(data: dict, microservice: str) -> dict:
     return {"exist": device is not None}
 
 
+@m.microservice_endpoint(path=["ping"])
+def ms_ping(data: dict, microservice: str) -> dict:
+    device: Optional[Device] = wrapper.session.query(Device).get(data["device_uuid"])
+
+    if device is None:
+        return device_not_found
+    else:
+        return {"online": device.powered_on}
+
+
 @m.microservice_endpoint(path=["owner"])
 def owner(data: dict, microservice: str) -> dict:
     device: Optional[Device] = wrapper.session.query(Device).get(data["device_uuid"])

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -16,6 +16,7 @@ from schemes import (
     requirement_file_move,
     requirement_file_update,
     requirement_file_create,
+    device_powered_off,
 )
 
 
@@ -34,6 +35,9 @@ def list_files(data: dict, user: str) -> dict:
 
     if not device.check_access(user):
         return permission_denied
+
+    if not device.powered_on:
+        return device_powered_off
 
     return {"files": [f.serialize for f in wrapper.session.query(File).filter_by(device=device.uuid).all()]}
 
@@ -57,6 +61,9 @@ def file_info(data: dict, user: str) -> dict:
     if not device.check_access(user):
         return permission_denied
 
+    if not device.powered_on:
+        return device_powered_off
+
     file: Optional[File] = wrapper.session.query(File).filter_by(device=device_uuid, uuid=file_uuid).first()
 
     if file is None:
@@ -77,6 +84,8 @@ def move(data: dict, user: str) -> dict:
         return device_not_found
     if not device.check_access(user):
         return permission_denied
+    if not device.powered_on:
+        return device_powered_off
 
     file: Optional[File] = wrapper.session.query(File).filter_by(device=device_uuid, uuid=file_uuid).first()
 
@@ -112,6 +121,8 @@ def update(data: dict, user: str) -> dict:
         return device_not_found
     if not device.check_access(user):
         return permission_denied
+    if not device.powered_on:
+        return device_powered_off
 
     file: Optional[File] = wrapper.session.query(File).filter_by(device=device_uuid, uuid=file_uuid).first()
 
@@ -144,6 +155,9 @@ def delete_file(data: dict, user: str) -> dict:
     if not device.check_access(user):
         return permission_denied
 
+    if not device.powered_on:
+        return device_powered_off
+
     file: Optional[File] = wrapper.session.query(File).filter_by(device=device_uuid, uuid=file_uuid).first()
 
     if file is None:
@@ -170,6 +184,9 @@ def create_file(data: dict, user: str) -> dict:
 
     if not device.check_access(user):
         return permission_denied
+
+    if not device.powered_on:
+        return device_powered_off
 
     filename: str = data["filename"]
     content: str = data["content"]

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -15,6 +15,8 @@ permission_denied: dict = make_error("permission_denied", origin="user")
 
 device_not_found: dict = make_error("device_not_found", origin="user")
 
+device_powered_off: dict = make_error("device_powered_off", origin="user")
+
 file_not_found: dict = make_error("file_not_found", origin="user")
 
 file_already_exists: dict = make_error("file_already_exists", origin="user")

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -354,6 +354,25 @@ class TestDevice(TestCase):
         self.assertEqual(expected_result, actual_result)
         self.query_device.get.assert_called_with("my device")
 
+    def test__ms_endpoint__ping__device_not_found(self):
+        self.query_device.get.return_value = None
+
+        expected_result = device_not_found
+        actual_result = device.ms_ping({"device_uuid": "my device"}, "")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with("my device")
+
+    def test__ms_endpoint__ping__successful(self):
+        mock_device = mock.MagicMock()
+        self.query_device.get.return_value = mock_device
+
+        expected_result = {"online": mock_device.powered_on}
+        actual_result = device.ms_ping({"device_uuid": "my device"}, "")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with("my device")
+
     def test__ms_endpoint__owner__device_not_found(self):
         self.query_device.get.return_value = None
 

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -8,7 +8,14 @@ from models.hardware import Hardware
 from models.service import Service
 from models.workload import Workload
 from resources import device
-from schemes import device_not_found, permission_denied, success, already_own_a_device, maximum_devices_reached
+from schemes import (
+    device_not_found,
+    permission_denied,
+    success,
+    already_own_a_device,
+    maximum_devices_reached,
+    device_powered_off,
+)
 from vars import hardware
 
 
@@ -256,9 +263,23 @@ class TestDevice(TestCase):
         self.query_device.get.assert_called_with("the-device")
         mock_device.check_access.assert_called_with("user")
 
+    def test__user_endpoint__device_change_name__device_powered_off(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_device.powered_on = False
+        self.query_device.get.return_value = mock_device
+
+        expected_result = device_powered_off
+        actual_result = device.change_name({"device_uuid": "the-device"}, "user")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with("the-device")
+        mock_device.check_access.assert_called_with("user")
+
     def test__user_endpoint__device_change_name__successful(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
         self.query_device.get.return_value = mock_device
 
         expected_result = mock_device.serialize

--- a/app/tests/test_file.py
+++ b/app/tests/test_file.py
@@ -6,7 +6,14 @@ from models.device import Device
 from models.file import File
 
 from resources import file
-from schemes import device_not_found, permission_denied, file_not_found, file_already_exists, success
+from schemes import (
+    device_not_found,
+    permission_denied,
+    file_not_found,
+    file_already_exists,
+    success,
+    device_powered_off,
+)
 
 
 class TestFile(TestCase):
@@ -45,9 +52,24 @@ class TestFile(TestCase):
         self.query_device.get.assert_called_with("my-device")
         mock_device.check_access.assert_called_with("user")
 
+    def test__user_endpoint__file_all__device_powered_off(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_device.powered_on = False
+
+        self.query_device.get.return_value = mock_device
+
+        expected_result = device_powered_off
+        actual_result = file.list_files({"device_uuid": "my-device"}, "user")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with("my-device")
+        mock_device.check_access.assert_called_with("user")
+
     def test__user_endpoint__file_all__successful(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
         files = [mock.MagicMock() for _ in range(5)]
 
         self.query_device.get.return_value = mock_device
@@ -83,9 +105,24 @@ class TestFile(TestCase):
         self.query_device.get.assert_called_with("my-device")
         mock_device.check_access.assert_called_with("user")
 
+    def test__user_endpoint__file_info__device_powered_off(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_device.powered_on = False
+
+        self.query_device.get.return_value = mock_device
+
+        expected_result = device_powered_off
+        actual_result = file.file_info({"device_uuid": "my-device", "file_uuid": "my-file"}, "user")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with("my-device")
+        mock_device.check_access.assert_called_with("user")
+
     def test__user_endpoint__file_info__file_not_found(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
 
         self.query_device.get.return_value = mock_device
         self.query_file.filter_by().first.return_value = None
@@ -101,6 +138,7 @@ class TestFile(TestCase):
     def test__user_endpoint__file_info__successful(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
         mock_file = mock.MagicMock()
 
         self.query_device.get.return_value = mock_device
@@ -136,9 +174,24 @@ class TestFile(TestCase):
         self.query_device.get.assert_called_with("my-device")
         mock_device.check_access.assert_called_with("user")
 
+    def test__user_endpoint__file_move__device_powered_off(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_device.powered_on = False
+
+        self.query_device.get.return_value = mock_device
+
+        expected_result = device_powered_off
+        actual_result = file.move({"device_uuid": "my-device", "file_uuid": "my-file", "filename": "new-name"}, "user")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with("my-device")
+        mock_device.check_access.assert_called_with("user")
+
     def test__user_endpoint__file_move__file_not_found(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
 
         self.query_device.get.return_value = mock_device
         self.query_file.filter_by().first.return_value = None
@@ -156,6 +209,7 @@ class TestFile(TestCase):
     def test__user_endpoint__file_move__file_already_exists(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
         mock_file = mock.MagicMock()
 
         self.query_device.get.return_value = mock_device
@@ -184,6 +238,7 @@ class TestFile(TestCase):
     def test__user_endpoint__file_move__successful(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
         mock_file = mock.MagicMock()
 
         self.query_device.get.return_value = mock_device
@@ -233,9 +288,24 @@ class TestFile(TestCase):
         self.query_device.get.assert_called_with("my-device")
         mock_device.check_access.assert_called_with("user")
 
+    def test__user_endpoint__file_update__device_powered_off(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_device.powered_on = False
+
+        self.query_device.get.return_value = mock_device
+
+        expected_result = device_powered_off
+        actual_result = file.update({"device_uuid": "my-device", "file_uuid": "my-file", "content": "test"}, "user")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with("my-device")
+        mock_device.check_access.assert_called_with("user")
+
     def test__user_endpoint__file_update__file_not_found(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
 
         self.query_device.get.return_value = mock_device
         self.query_file.filter_by().first.return_value = None
@@ -253,6 +323,7 @@ class TestFile(TestCase):
     def test__user_endpoint__file_update__successful(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
         mock_file = mock.MagicMock()
 
         self.query_device.get.return_value = mock_device
@@ -292,9 +363,24 @@ class TestFile(TestCase):
         self.query_device.get.assert_called_with("my-device")
         mock_device.check_access.assert_called_with("user")
 
+    def test__user_endpoint__file_delete__device_powered_off(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_device.powered_on = False
+
+        self.query_device.get.return_value = mock_device
+
+        expected_result = device_powered_off
+        actual_result = file.delete_file({"device_uuid": "my-device", "file_uuid": "my-file"}, "user")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with("my-device")
+        mock_device.check_access.assert_called_with("user")
+
     def test__user_endpoint__file_delete__file_not_found(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
 
         self.query_device.get.return_value = mock_device
         self.query_file.filter_by().first.return_value = None
@@ -310,6 +396,7 @@ class TestFile(TestCase):
     def test__user_endpoint__file_delete__successful(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
         mock_file = mock.MagicMock()
 
         self.query_device.get.return_value = mock_device
@@ -347,9 +434,24 @@ class TestFile(TestCase):
         self.query_device.get.assert_called_with("my-device")
         mock_device.check_access.assert_called_with("user")
 
+    def test__user_endpoint__file_create__device_powered_off(self):
+        mock_device = mock.MagicMock()
+        mock_device.check_access.return_value = True
+        mock_device.powered_on = False
+
+        self.query_device.get.return_value = mock_device
+
+        expected_result = device_powered_off
+        actual_result = file.create_file({"device_uuid": "my-device"}, "user")
+
+        self.assertEqual(expected_result, actual_result)
+        self.query_device.get.assert_called_with("my-device")
+        mock_device.check_access.assert_called_with("user")
+
     def test__user_endpoint__file_create__file_already_exists(self):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
 
         self.query_device.get.return_value = mock_device
         self.query_func_count.filter_by().scalar.return_value = 1
@@ -369,6 +471,7 @@ class TestFile(TestCase):
     def test__user_endpoint__file_create__successful(self, file_create_patch):
         mock_device = mock.MagicMock()
         mock_device.check_access.return_value = True
+        mock_device.powered_on = True
 
         self.query_device.get.return_value = mock_device
         self.query_func_count.filter_by().scalar.return_value = 0

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -86,6 +86,7 @@ class TestApp(TestCase):
 
         expected_ms_endpoints = [
             (["exist"], device.exist),
+            (["ping"], device.ms_ping),
             (["owner"], device.owner),
             (["hardware", "register"], hardware.hardware_register),
             (["hardware", "stop"], hardware.hardware_stop),


### PR DESCRIPTION
## Description
Added checks to make sure the device is powered on in the `/device/change_name` endpoint and the file endpoints. Also added a `/ping` microservice endpoint.

## Related Issue
#73 

## How Has This Been Tested?
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
