### PR TITLE
call device init in service 

### DIFF
--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -150,12 +150,16 @@ def power(data: dict, user: str, device: Device) -> dict:
     :return: The response
     """
 
+    device_uuid: str = data["device_uuid"]
+
     device.powered_on = not device.powered_on
     wrapper.session.commit()
 
     if not device.powered_on:
-        stop_all_service(data["device_uuid"])
-        stop_services(data["device_uuid"])
+        stop_all_service(device_uuid)
+        stop_services(device_uuid)
+    else:
+        m.contact_microservice("service", ["device_restart"], {"device_uuid": device_uuid, "user": device.owner})
 
     return device.serialize
 

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -107,6 +107,8 @@ def create_device(data: dict, user: str) -> dict:
 
     delete_items(user, data)
 
+    m.contact_microservice("service", ["device_init"], {"device_uuid": device.uuid, "user": device.owner})
+
     return device.serialize
 
 
@@ -131,6 +133,8 @@ def starter_device(data: dict, user: str) -> dict:
     Workload.create(device.uuid, performance)
 
     create_hardware(hardware["start_pc"], device.uuid)
+
+    m.contact_microservice("service", ["device_init"], {"device_uuid": device.uuid, "user": device.owner})
 
     return device.serialize
 

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -179,6 +179,9 @@ class TestDevice(TestCase):
 
         self.assertEqual(expected_result, actual_result)
         self.assertTrue(mock_device.powered_on)
+        mock.m.contact_microservice.assert_called_with(
+            "service", ["device_restart"], {"device_uuid": "my-device", "user": mock_device.owner}
+        )
 
     @patch("resources.device.stop_services")
     @patch("resources.device.stop_all_service")

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -131,6 +131,9 @@ class TestDevice(TestCase):
         workload_patch.create.assert_called_with(mock_device.uuid, calculate_patch())
         create_patch.assert_called_with(data, mock_device.uuid)
         delete_patch.assert_called_with("user", data)
+        mock.m.contact_microservice.assert_called_with(
+            "service", ["device_init"], {"device_uuid": mock_device.uuid, "user": mock_device.owner}
+        )
 
     def test__user_endpoint__device_starter_device__already_own_a_device(self):
         self.query_func_count.filter_by().scalar.return_value = 1
@@ -163,6 +166,9 @@ class TestDevice(TestCase):
         device_create_patch.assert_called_with("user", True)
         workload_patch.create.assert_called_with(mock_device.uuid, calculate_patch())
         create_patch.assert_called_with(hardware["start_pc"], mock_device.uuid)
+        mock.m.contact_microservice.assert_called_with(
+            "service", ["device_init"], {"device_uuid": mock_device.uuid, "user": mock_device.owner}
+        )
 
     def test__user_endpoint__device_power__turn_on(self):
         mock_device = self.query_device.get()

--- a/app/vars.py
+++ b/app/vars.py
@@ -55,13 +55,7 @@ hardware = {
     "processorCooler": [{"name": "CPU Cooler Mini", "coolerSpeed": 1, "sockel": "XT2019", "power": 10}],
     "ram": {
         "Crossfire ZX100": {"name": "Crossfire ZX100", "ramSize": 256, "ramTyp": "DDR1", "frequency": 422, "power": 5},
-        "Crossfire ZX1000": {
-            "name": "Crossfire ZX100",
-            "ramSize": 512,
-            "ramTyp": "DDR1",
-            "frequency": 422,
-            "power": 5,
-        },
+        "Crossfire ZX1000": {"name": "Crossfire ZX100", "ramSize": 512, "ramTyp": "DDR1", "frequency": 422, "power": 5},
     },
     "gpu": {
         "Forcevid MX1000": {


### PR DESCRIPTION
## Description
 When creating a new device call the `/device_init` endpoint in cryptic-service.

## Related Issue
#77 

## How Has This Been Tested?
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
