### PR TITLE
restore hardware when device is deleted

### DIFF
--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -1,9 +1,9 @@
 from typing import List, Optional
 
+from cryptic import register_errors
 from sqlalchemy import func
 
 from app import m, wrapper
-from cryptic import register_errors
 from models.device import Device
 from models.file import File
 from models.hardware import Hardware
@@ -199,10 +199,21 @@ def delete_device(data: dict, user: str, device: Device) -> dict:
     if device.owner != user:
         return permission_denied
 
-    stop_all_service(data["device_uuid"], delete=True)
-    delete_services(data["device_uuid"])  # Removes all Services in MS_Service
+    stop_all_service(device.uuid, delete=True)
+    delete_services(device.uuid)  # Removes all Services in MS_Service
 
-    device: Device = wrapper.session.query(Device).get(data["device_uuid"])
+    for file in wrapper.session.query(File).filter_by(device=device.uuid):
+        wrapper.session.delete(file)
+
+    for hw in wrapper.session.query(Hardware).filter_by(device_uuid=device.uuid):
+        m.contact_microservice(
+            "inventory",
+            ["inventory", "create"],
+            {"item_name": hw.hardware_element, "owner": device.owner, "related_ms": "device"},
+        )
+        wrapper.session.delete(hw)
+
+    device: Device = wrapper.session.query(Device).get(device.uuid)
     wrapper.session.delete(device)
     wrapper.session.commit()
 

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -222,15 +222,32 @@ class TestDevice(TestCase):
         mock_device = mock.MagicMock()
         mock_device.owner = "user"
         self.query_device.get.return_value = mock_device
+        files = self.query_file.filter_by.return_value = [mock.MagicMock() for _ in range(5)]
+        hw = self.query_hardware.filter_by.return_value = [mock.MagicMock() for _ in range(5)]
+        hw_names = [h.hardware_element for h in hw]
+        to_delete = files + hw + [mock_device]
+        restored_hardware = []
+        mock.wrapper.session.delete.side_effect = to_delete.remove
+
+        def contact_microservice_handler(ms, path, data):
+            self.assertEqual("inventory", ms)
+            self.assertEqual(["inventory", "create"], path)
+            restored_hardware.append(data.pop("item_name"))
+            self.assertEqual(mock_device.owner, data.pop("owner"))
+            self.assertEqual("device", data.pop("related_ms"))
+            self.assertFalse(data)
+
+        mock.m.contact_microservice.side_effect = contact_microservice_handler
 
         expected_result = success
-        actual_result = device.delete_device({"device_uuid": "the-device"}, "user", mock_device)
+        actual_result = device.delete_device({}, "user", mock_device)
 
         self.assertEqual(expected_result, actual_result)
-        self.query_device.get.assert_called_with("the-device")
-        sas_patch.assert_called_with("the-device", delete=True)
-        ds_patch.assert_called_with("the-device")
-        mock.wrapper.session.delete.assert_called_with(mock_device)
+        self.query_device.get.assert_called_with(mock_device.uuid)
+        sas_patch.assert_called_with(mock_device.uuid, delete=True)
+        ds_patch.assert_called_with(mock_device.uuid)
+        self.assertFalse(to_delete)
+        self.assertEqual(hw_names, restored_hardware)
         mock.wrapper.session.commit.assert_called_with()
 
     @patch("resources.device.Device")


### PR DESCRIPTION
## Description
Fixed `/device/delete` endpoint to put the hardware back into the users inventory.

## Related Issue
#81 

## How Has This Been Tested?
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
