### PR TITLE
insufficient restrictions for special file names

### DIFF
--- a/app/schemes.py
+++ b/app/schemes.py
@@ -61,7 +61,7 @@ requirement_file_delete: dict = {"device_uuid": UUID(), "file_uuid": UUID()}
 requirement_file_move: dict = {
     "device_uuid": UUID(),
     "file_uuid": UUID(),
-    "new_filename": Text(pattern=r"^[a-zA-Z0-9\-_.]{1,64}$"),
+    "new_filename": Text(pattern=r"^(?!\.+$)[a-zA-Z0-9\-_.]{1,64}$"),
     "new_parent_dir_uuid": UUID(),
 }
 
@@ -69,7 +69,7 @@ requirement_file_update: dict = {"device_uuid": UUID(), "file_uuid": UUID(), "co
 
 requirement_file_create: dict = {
     "device_uuid": UUID(),
-    "filename": Text(pattern=r"^[a-zA-Z0-9\-_.]{1,64}$"),
+    "filename": Text(pattern=r"^(?!\.+$)[a-zA-Z0-9\-_.]{1,64}$"),
     "content": Text(max_length=CONTENT_LENGTH),
     "is_directory": Boolean(),
     "parent_dir_uuid": UUID(),


### PR DESCRIPTION
## Description
Fixed regular expressions for filenames to prevent names like `.` or `..`.

## Related Issue
fixes #88 

## How Has This Been Tested?
unit tests and tested with docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
