### PR TITLE
device create does not work for large user inventories

### DIFF
--- a/app/tests/test_game_content.py
+++ b/app/tests/test_game_content.py
@@ -55,10 +55,16 @@ class TestGameContent(TestCase):
             {},
         ]
 
+        def build_summary_response(missing):
+            out = {}
+            for element in elements:
+                if element == missing:
+                    continue
+                out[element] = out.get(element, 0) + 1
+            return {"elements": out}
+
         for missing_element, expected_result in zip(elements, expected_results):
-            mock.m.contact_microservice.return_value = {
-                "elements": [{"element_name": e} for e in elements if e != missing_element]
-            }
+            mock.m.contact_microservice.return_value = build_summary_response(missing_element)
 
             actual_result = game_content.check_exists(
                 "super",
@@ -75,7 +81,7 @@ class TestGameContent(TestCase):
             )
 
             self.assertEqual((not expected_result, expected_result), actual_result)
-            mock.m.contact_microservice.assert_called_with("inventory", ["inventory", "list"], {"owner": "super"})
+            mock.m.contact_microservice.assert_called_with("inventory", ["inventory", "summary"], {"owner": "super"})
             mock.reset_mocks()
 
     def test__delete_items(self):


### PR DESCRIPTION
## Description
Fixed `check_exists` function to use the new `inventory/summary` endpoint to reduce the size of the json objects.

## Related Issue
#91 

## How Has This Been Tested?
unit tests and tested with docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
