### PR TITLE
does not catch cant move directory into itself exception 

### DIFF
--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -82,7 +82,7 @@ def move(data: dict, user: str, device: Device, file: File) -> dict:
             device=device.uuid, uuid=new_parent_dir_uuid
         ).first()
         if parent_to_check is not None:
-            while parent_to_check.uuid is not None:
+            while parent_to_check is not None:
                 if parent_to_check.uuid == file.uuid:
                     return can_not_move_dir_into_itself
                 parent_to_check: Optional[File] = wrapper.session.query(File).filter_by(

--- a/app/resources/file.py
+++ b/app/resources/file.py
@@ -82,7 +82,7 @@ def move(data: dict, user: str, device: Device, file: File) -> dict:
             device=device.uuid, uuid=new_parent_dir_uuid
         ).first()
         if parent_to_check is not None:
-            while parent_to_check.parent_dir_uuid is not None:
+            while parent_to_check.uuid is not None:
                 if parent_to_check.uuid == file.uuid:
                     return can_not_move_dir_into_itself
                 parent_to_check: Optional[File] = wrapper.session.query(File).filter_by(

--- a/app/tests/test_file.py
+++ b/app/tests/test_file.py
@@ -153,11 +153,10 @@ class TestFile(TestCase):
         mock_file = mock.MagicMock()
         mock_file.is_directory = True
         mock_file.uuid = "3"
-        filesystem = {}
         dir_mock = mock.MagicMock()
         dir_mock.parent_dir_uuid = None
         dir_mock.uuid = "0"
-        filesystem.update({str(0): dir_mock})
+        filesystem = {"0": dir_mock, None: None}
 
         self.query_device.get.return_value = mock_device
 


### PR DESCRIPTION
**Description**
Fixed move function to catch `cant move directory into itself exception` 

**Issue**
Closes #94 

**Testing Instructions**
unit tests and tested with docker

**Additional Notes**
> Add any other context about the pull request here.
