### PR TITLE
Issue/96 start device cannot be deleted

### DIFF
--- a/app/models/device.py
+++ b/app/models/device.py
@@ -19,6 +19,7 @@ class Device(wrapper.Base):
     name: Union[Column, str] = Column(String(255), nullable=False)
     owner: Union[Column, str] = Column(String(36), nullable=False)
     powered_on: Union[Column, bool] = Column(Boolean, nullable=False, default=False)
+    starter_device: Union[Column, bool] = Column(Boolean, nullable=False, default=False)
 
     @property
     def serialize(self) -> Dict[str, Any]:
@@ -30,7 +31,11 @@ class Device(wrapper.Base):
         return d
 
     @staticmethod
-    def create(user: str, powered_on: bool) -> "Device":
+    def create_starter_device(user: str, powered_on: bool) -> "Device":
+        return Device.create(user, powered_on, True)
+
+    @staticmethod
+    def create(user: str, powered_on: bool, starter_device: Optional[bool] = False) -> "Device":
         """
         Creates a new device.
         :param user: The owner's uuid
@@ -65,7 +70,7 @@ class Device(wrapper.Base):
         )
 
         # Return a new device
-        device: Device = Device(uuid=uuid, name=name, owner=user, powered_on=powered_on)
+        device: Device = Device(uuid=uuid, name=name, owner=user, powered_on=powered_on, starter_device=starter_device)
 
         wrapper.session.add(device)
         wrapper.session.commit()

--- a/app/resources/device.py
+++ b/app/resources/device.py
@@ -30,6 +30,7 @@ from schemes import (
     already_own_a_device,
     maximum_devices_reached,
     device_not_found,
+    device_is_starter_device,
 )
 from vars import hardware
 
@@ -131,7 +132,7 @@ def starter_device(data: dict, user: str) -> dict:
 
     performance: tuple = calculate_power(hardware["start_pc"])
 
-    device: Device = Device.create(user, True)
+    device: Device = Device.create_starter_device(user, True)
 
     Workload.create(device.uuid, performance)
 
@@ -200,6 +201,9 @@ def delete_device(data: dict, user: str, device: Device) -> dict:
 
     if device.owner != user:
         return permission_denied
+
+    if device.starter_device:
+        return device_is_starter_device
 
     stop_all_service(device.uuid, delete=True)
     delete_services(device.uuid)  # Removes all Services in MS_Service

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -35,6 +35,8 @@ service_already_running: dict = make_error("service_already_running", origin="se
 
 service_not_running: dict = make_error("service_not_running", origin="service")
 
+device_is_starter_device: dict = make_error("device_is_starter_device", origin="service")
+
 success: dict = {"ok": True}
 
 requirement_device: dict = {"device_uuid": UUID()}

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -173,7 +173,7 @@ class TestDevice(TestCase):
         self.sqlalchemy_func.count.assert_called_with(Device.uuid)
         self.query_func_count.filter_by.assert_called_with(owner="user")
         calculate_patch.assert_called_with(hardware["start_pc"])
-        device_create_patch.assert_called_with("user", True)
+        device_create_patch.assert_called_with("user", True, True)
         workload_patch.create.assert_called_with(mock_device.uuid, calculate_patch())
         create_patch.assert_called_with(hardware["start_pc"], mock_device.uuid)
         mock.m.contact_microservice.assert_called_with(
@@ -231,6 +231,7 @@ class TestDevice(TestCase):
     def test__user_endpoint__device_delete__successful(self, sas_patch, ds_patch):
         mock_device = mock.MagicMock()
         mock_device.owner = "user"
+        mock_device.starter_device = False
         files = []
         for i in range(5):
             files.append([mock.MagicMock() for _ in range(5)])

--- a/app/tests/test_device.py
+++ b/app/tests/test_device.py
@@ -8,7 +8,14 @@ from models.hardware import Hardware
 from models.service import Service
 from models.workload import Workload
 from resources import device
-from schemes import permission_denied, success, already_own_a_device, maximum_devices_reached, device_not_found
+from schemes import (
+    permission_denied,
+    success,
+    already_own_a_device,
+    maximum_devices_reached,
+    device_not_found,
+    device_is_starter_device,
+)
 from vars import hardware
 
 
@@ -222,6 +229,16 @@ class TestDevice(TestCase):
         mock_device.owner = "other-user"
 
         expected_result = permission_denied
+        actual_result = device.delete_device({"device_uuid": "the-device"}, "user", mock_device)
+
+        self.assertEqual(expected_result, actual_result)
+
+    def test__user_endpoint__device_delete__starter_device(self):
+        mock_device = mock.MagicMock()
+        mock_device.owner = "user"
+        mock_device.starter_device = True
+
+        expected_result = device_is_starter_device
         actual_result = device.delete_device({"device_uuid": "the-device"}, "user", mock_device)
 
         self.assertEqual(expected_result, actual_result)


### PR DESCRIPTION
**Description**
I've added a flag if the device is a starter device. This flag will be set when the starter device is created. This flag will be true if the starter device is created. If another device is created the starter_device flag will be set to False. During deletion it will be checked if the device is a starter device. If the device is a starter device an error will be sent to the client and the device won't be deleted.

**Issue**
Closes #96 

**Testing Instructions**
1. Create a starter device
2. Create another device
3. Try to delete the starter device
4. Check if you get "device_is_starter_device" error
5. Try to delete the other device
6. Device should be deleted

**Additional Notes**
uwu
